### PR TITLE
New Editor UI & Publish draft version

### DIFF
--- a/src/components/Editor/AddModal.js
+++ b/src/components/Editor/AddModal.js
@@ -1,0 +1,44 @@
+import React, { useState } from "react";
+import Modal from "react-bootstrap/Modal";
+
+export default function OpenModal({ onHide, onOpen, onNew, show }) {
+  const [widgetSrc, setWidgetSrc] = useState("");
+
+  return (
+    <Modal centered scrollable show={show} onHide={onHide}>
+      <Modal.Header closeButton>
+        <Modal.Title>Add a Component</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <div className="text-secondary mb-4">
+          Open existing components, or create your own.
+        </div>
+        <div>
+          <button
+            className="btn btn-outline-success w-100 mb-3"
+            onClick={(e) => {
+              e.preventDefault();
+              onOpen(widgetSrc);
+              onHide();
+            }}
+          >
+            Open Component
+          </button>
+        </div>
+        <div className="w-100 text-center text-secondary mb-3">or</div>
+        <div>
+          <button
+            className="btn btn-success w-100 mb-4"
+            onClick={(e) => {
+              e.preventDefault();
+              onNew(widgetSrc);
+              onHide();
+            }}
+          >
+            Create New Component
+          </button>
+        </div>
+      </Modal.Body>
+    </Modal>
+  );
+}

--- a/src/components/Editor/CreateModal.js
+++ b/src/components/Editor/CreateModal.js
@@ -12,11 +12,11 @@ export default function OpenModal(props) {
   return (
     <Modal centered scrollable show={show} onHide={onHide}>
       <Modal.Header closeButton>
-        <Modal.Title>Open a Component</Modal.Title>
+        <Modal.Title>Create New Component</Modal.Title>
       </Modal.Header>
       <Modal.Body>
         <label htmlFor="widget-src-input" className="form-label text-secondary">
-          Widget name <span className="text-muted">(or path)</span>
+          Component name
         </label>
         <input
           className="form-control"
@@ -31,15 +31,15 @@ export default function OpenModal(props) {
       <Modal.Footer>
         <button
           className="btn btn-success"
-          disabled={!widgetSrc}
+          disabled={widgetSrc && widgetSrc.indexOf("/") !== -1}
           onClick={(e) => {
             e.preventDefault();
-            onOpen(widgetSrc);
+            onNew(widgetSrc);
             setWidgetSrc("");
             onHide();
           }}
         >
-          Open
+          Create
         </button>
         <button className="btn btn-secondary" onClick={onHide}>
           Cancel

--- a/src/components/Editor/RenameModal.js
+++ b/src/components/Editor/RenameModal.js
@@ -12,10 +12,10 @@ export default function RenameModal(props) {
   return (
     <Modal centered scrollable show={show} onHide={onHide}>
       <Modal.Header closeButton>
-        <Modal.Title>Rename</Modal.Title>
+        <Modal.Title>Rename Component</Modal.Title>
       </Modal.Header>
       <Modal.Body>
-        <label htmlFor="rename-input" className="form-label">
+        <label htmlFor="rename-input" className="form-label text-secondary">
           New name
         </label>
         <input
@@ -41,7 +41,7 @@ export default function RenameModal(props) {
           Confirm
         </button>
         <button className="btn btn-secondary" onClick={onHide}>
-          Close
+          Cancel
         </button>
       </Modal.Footer>
     </Modal>

--- a/src/components/SaveDraft.js
+++ b/src/components/SaveDraft.js
@@ -10,7 +10,12 @@ export const SaveDraftModal = (props) => {
     const show = props.show;
     const onHide = props.onHide;
     const near = props.near;
-  
+    
+    const onCancel = (e) => {
+      e.preventDefault();
+      setCommitMessage("");
+      onHide();
+    };
   
     return (
       <Modal size="xl" centered scrollable show={show} onHide={onHide}>
@@ -58,7 +63,7 @@ export const SaveDraftModal = (props) => {
         </CommitButton>
           <button
             className="btn btn-secondary"
-            onClick={onHide}
+            onClick={onCancel}
           >
             Cancel
           </button>

--- a/src/components/SaveDraft.js
+++ b/src/components/SaveDraft.js
@@ -1,73 +1,75 @@
 import React, { useState } from "react";
-import { CommitButton } from "near-social-vm";;
+import { CommitButton } from "near-social-vm";
 import Modal from "react-bootstrap/Modal";
 
 export const SaveDraftModal = (props) => {
-    const [commitMessage, setCommitMessage] = useState("");
-   
-    const code = props.code;
-    const widgetPath = props.widgetPath + "/branch/draft";
-    const show = props.show;
-    const onHide = props.onHide;
-    const near = props.near;
-    
-    const onCancel = (e) => {
-      e.preventDefault();
-      setCommitMessage("");
-      onHide();
-    };
-  
-    return (
-      <Modal size="xl" centered scrollable show={show} onHide={onHide}>
-        <Modal.Header closeButton>
-          <Modal.Title>Saving draft</Modal.Title>
-        </Modal.Header>
-        <Modal.Body>
-            <div>
-              <h5>Optional commit message for your draft:</h5>
-              <input
-                className="form-control"
-                id="widget-src-input"
-                type="text"
-                value={commitMessage}
-                onChange={(e) =>
-                  setCommitMessage(e.target.value)
-                }
-              />
-            </div>
-        </Modal.Body>
-        <Modal.Footer>
+  const [commitMessage, setCommitMessage] = useState("");
+
+  const code = props.code;
+  const widgetPath = props.widgetPath + "/branch/draft";
+  const show = props.show;
+  const onHide = props.onHide;
+  const near = props.near;
+
+  const onCancel = (e) => {
+    e.preventDefault();
+    setCommitMessage("");
+    onHide();
+  };
+
+  return (
+    <Modal centered scrollable show={show} onHide={onHide}>
+      <Modal.Header closeButton>
+        <Modal.Title>Save to Version History</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <div>
+          <div className="text-secondary mb-4">
+            Save and commit your changes to the on-chain version history. Give
+            your version a description what changed. Then save to the on-chain
+            version history.
+          </div>
+          <label htmlFor="rename-input" className="form-label text-secondary">
+            Describe what changed
+          </label>
+          <input
+            className="form-control"
+            id="widget-src-input"
+            type="text"
+            value={commitMessage}
+            onChange={(e) => setCommitMessage(e.target.value)}
+          />
+        </div>
+      </Modal.Body>
+      <Modal.Footer>
         <CommitButton
           className="btn btn-primary"
           near={near}
           data={{
-            post:{
+            post: {
               commit: {
                 text: commitMessage,
                 type: "md",
-                keys: [widgetPath]
-              }
+                keys: [widgetPath],
+              },
             },
             widget: {
               [props.widgetName]: {
                 branch: {
                   draft: {
-                    "": code
-                  }
-                }
+                    "": code,
+                  },
+                },
               },
             },
           }}
         >
-          Save Draft
+          Save
         </CommitButton>
-          <button
-            className="btn btn-secondary"
-            onClick={onCancel}
-          >
-            Cancel
-          </button>
-        </Modal.Footer>
-      </Modal>
-    );
+        <button className="btn btn-secondary" onClick={onCancel}>
+          Cancel
+        </button>
+      </Modal.Footer>
+    </Modal>
+  );
 };

--- a/src/components/SaveDraft.js
+++ b/src/components/SaveDraft.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { CommitButton } from "./Commit";
+import { CommitButton } from "near-social-vm";;
 import Modal from "react-bootstrap/Modal";
 
 export const SaveDraftModal = (props) => {

--- a/src/components/SaveDraft.js
+++ b/src/components/SaveDraft.js
@@ -1,0 +1,68 @@
+import React, { useState } from "react";
+import { CommitButton } from "./Commit";
+import Modal from "react-bootstrap/Modal";
+
+export const SaveDraftModal = (props) => {
+    const [commitMessage, setCommitMessage] = useState("");
+   
+    const code = props.code;
+    const widgetPath = props.widgetPath + "/branch/draft";
+    const show = props.show;
+    const onHide = props.onHide;
+    const near = props.near;
+  
+  
+    return (
+      <Modal size="xl" centered scrollable show={show} onHide={onHide}>
+        <Modal.Header closeButton>
+          <Modal.Title>Saving draft</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+            <div>
+              <h5>Optional commit message for your draft:</h5>
+              <input
+                className="form-control"
+                id="widget-src-input"
+                type="text"
+                value={commitMessage}
+                onChange={(e) =>
+                  setCommitMessage(e.target.value)
+                }
+              />
+            </div>
+        </Modal.Body>
+        <Modal.Footer>
+        <CommitButton
+          className="btn btn-primary"
+          near={near}
+          data={{
+            post:{
+              commit: {
+                text: commitMessage,
+                type: "md",
+                keys: [widgetPath]
+              }
+            },
+            widget: {
+              [props.widgetName]: {
+                branch: {
+                  draft: {
+                    "": code
+                  }
+                }
+              },
+            },
+          }}
+        >
+          Save Draft
+        </CommitButton>
+          <button
+            className="btn btn-secondary"
+            onClick={onHide}
+          >
+            Cancel
+          </button>
+        </Modal.Footer>
+      </Modal>
+    );
+};

--- a/src/pages/EditorPage.js
+++ b/src/pages/EditorPage.js
@@ -317,53 +317,6 @@ export default function EditorPage(props) {
   }, [code]);
 
   useEffect(() => {
-    if (files) {
-      files.forEach((f) => {
-        const widgetSrc = `${accountId}/widget/${f.name}/**`;
-        const fetchCodeAndDraftOnChain = () => {
-          const widgetCode = cache.socialGet(
-            near,
-            widgetSrc,
-            false,
-            undefined,
-            undefined,
-            fetchCodeAndDraftOnChain
-          );
-
-          const mainCode = widgetCode?.[""];
-          const draft = widgetCode?.branch?.draft?.[""];
-          const isDraft = (!draft && !mainCode) || draft;
-          const path = f;
-
-          cache
-            .asyncLocalStorageGet(StorageDomain, {
-              path,
-              type: StorageType.Code,
-            })
-            .then(({ code }) => {
-              let hasCodeChanged;
-              if (draft) {
-                hasCodeChanged = draft != code;
-              } else if (mainCode) {
-                hasCodeChanged = mainCode != code;
-              } else {
-                // no code on chain
-                hasCodeChanged = true;
-              }
-              setFilesDetails(
-                filesDetails.set(f.name, {
-                  codeChangesPresent: hasCodeChanged,
-                  isDraft,
-                })
-              );
-            });
-        };
-        fetchCodeAndDraftOnChain();
-      });
-    }
-  }, [code, files]);
-
-  useEffect(() => {
     ls.set(WidgetPropsKey, widgetProps);
     try {
       const parsedWidgetProps = JSON.parse(widgetProps);

--- a/src/pages/EditorPage.js
+++ b/src/pages/EditorPage.js
@@ -674,12 +674,6 @@ export default function EditorPage(props) {
     </button>
   );
 
-  const openCreateButton = (
-    <button className="btn btn-primary" onClick={() => setShowOpenModal(true)}>
-      Open / Create
-    </button>
-  );
-
   const renameButton = (
     <button
       className="btn btn-outline-success ms-2"

--- a/src/pages/EditorPage.js
+++ b/src/pages/EditorPage.js
@@ -14,7 +14,53 @@ import {
 import { Nav, OverlayTrigger, Tooltip } from "react-bootstrap";
 import RenameModal from "../components/Editor/RenameModal";
 import OpenModal from "../components/Editor/OpenModal";
-import VsCodeBanner from "../components/Editor/VsCodeBanner";
+import AddModal from "../components/Editor/AddModal";
+import CreateModal from "../components/Editor/CreateModal";
+import { SaveDraftModal } from "../components/SaveDraft";
+import styled from "styled-components";
+
+const TopMenu = styled.div`
+  border-radius: 0.375rem;
+  display: flex;
+  color: #11181c;
+  height: 40px;
+
+  &&& > a.active {
+    border: 1px solid #ced4da;
+  }
+  &&& > a {
+    background: #fff;
+    color: #11181c;
+    padding-left: 6px;
+    padding-right: 6px;
+  }
+
+  .draft {
+    height: 24px;
+    width: 50px;
+    line-height: 24px;
+    text-align: center;
+    font-weight: bold;
+    color: #ad5700;
+    font-size: 12px;
+    border-radius: 50px;
+    background-color: #ffecbc;
+    margin-right: 6px;
+  }
+
+  .dot {
+    background: #f45858;
+    width: 10px;
+    height: 10px;
+    border-radius: 100%;
+    margin: 7px 8px 0;
+  }
+
+  .close {
+    width: 28px;
+    height: 28px;
+  }
+`;
 
 const StorageDomain = {
   page: "editor",
@@ -59,7 +105,11 @@ export default function EditorPage(props) {
   const [files, setFiles] = useState(undefined);
   const [lastPath, setLastPath] = useState(undefined);
   const [showRenameModal, setShowRenameModal] = useState(false);
+  const [showSaveDraftModal, setShowSaveDraftModal] = useState(false);
+
+  const [showAddModal, setShowAddModal] = useState(false);
   const [showOpenModal, setShowOpenModal] = useState(false);
+  const [showCreateModal, setShowCreateModal] = useState(false);
 
   const [renderCode, setRenderCode] = useState(code);
   const [widgetProps, setWidgetProps] = useState(
@@ -68,6 +118,10 @@ export default function EditorPage(props) {
   const [parsedWidgetProps, setParsedWidgetProps] = useState({});
   const [propsError, setPropsError] = useState(null);
   const [metadata, setMetadata] = useState(undefined);
+  const [codeChangesPresent, setCodeChangesPresent] = useState(false);
+  const [codeOnChain, setCodeOnChain] = useState(null);
+  const [draftOnChain, setDraftOnChain] = useState(null);
+  const [filesDetails, setFilesDetails] = useState(new Map());
   const near = useNear();
   const cache = useCache();
   const accountId = useAccountId();
@@ -109,6 +163,158 @@ export default function EditorPage(props) {
     },
     [cache, setCode]
   );
+
+  useEffect(() => {
+    const widgetSrc = `${accountId}/widget/${widgetName}/**`;
+    const fetchCodeAndDraftOnChain = () => {
+      const widgetCode = cache.socialGet(
+        near,
+        widgetSrc,
+        false,
+        undefined,
+        undefined,
+        fetchCodeAndDraftOnChain
+      );
+
+      setCodeOnChain(widgetCode?.[""]);
+      setDraftOnChain(widgetCode?.branch?.draft?.[""]);
+    };
+    fetchCodeAndDraftOnChain();
+  }, [code]);
+
+  useEffect(() => {
+    let hasCodeChanged;
+    if (draftOnChain) {
+      hasCodeChanged = draftOnChain != code;
+    } else if (codeOnChain) {
+      hasCodeChanged = codeOnChain != code;
+    } else {
+      // no code on chain
+      hasCodeChanged = true;
+    }
+    setCodeChangesPresent(hasCodeChanged);
+  }, [code, codeOnChain, draftOnChain]);
+
+  const checkDrafts = () => {
+    files.forEach((f) => {
+      const widgetSrc = `${accountId}/widget/${f.name}/**`;
+      const fetchCodeAndDraftOnChain = () => {
+        const widgetCode = cache.socialGet(
+          near,
+          widgetSrc,
+          false,
+          undefined,
+          undefined,
+          fetchCodeAndDraftOnChain
+        );
+
+        const mainCode = widgetCode?.[""];
+        const draft = widgetCode?.branch?.draft?.[""];
+        const isDraft = (!draft && !mainCode) || draft;
+        const path = f;
+
+        setFilesDetails(
+          filesDetails.set(f.name, {
+            codeChangesPresent: filesDetails.get(f.name)?.codeChangesPresent,
+            isDraft,
+          })
+        );
+      };
+      fetchCodeAndDraftOnChain();
+    });
+  };
+
+  const checkHasCodeChange = () => {
+    files.forEach((f) => {
+      const widgetSrc = `${accountId}/widget/${f.name}/**`;
+      const fetchCodeAndDraftOnChain = () => {
+        const widgetCode = cache.socialGet(
+          near,
+          widgetSrc,
+          false,
+          undefined,
+          undefined,
+          fetchCodeAndDraftOnChain
+        );
+
+        const mainCode = widgetCode?.[""];
+
+        const draft = widgetCode?.branch?.draft?.[""];
+        const path = f;
+
+        cache
+          .asyncLocalStorageGet(StorageDomain, {
+            path,
+            type: StorageType.Code,
+          })
+          .then(({ code }) => {
+            let hasCodeChanged;
+            if (draft) {
+              hasCodeChanged = draft != code;
+            } else if (mainCode) {
+              hasCodeChanged = mainCode != code;
+            } else {
+              // no code on chain
+              hasCodeChanged = true;
+            }
+            setFilesDetails(
+              filesDetails.set(f.name, {
+                codeChangesPresent: hasCodeChanged,
+                isDraft: filesDetails.get(f.name)?.isDraft,
+              })
+            );
+          });
+      };
+      fetchCodeAndDraftOnChain();
+    });
+  };
+
+  const checkHasCodeChangeSingleFile = (code) => {
+    console.log("Z2");
+    const widgetSrc = `${accountId}/widget/${widgetName}/**`;
+    const fetchCodeAndDraftOnChain = () => {
+      const widgetCode = cache.socialGet(
+        near,
+        widgetSrc,
+        false,
+        undefined,
+        undefined,
+        fetchCodeAndDraftOnChain
+      );
+
+      const mainCode = widgetCode?.[""];
+      const draft = widgetCode?.branch?.draft?.[""];
+      let hasCodeChanged;
+      if (draft) {
+        hasCodeChanged = draft != code;
+      } else if (mainCode) {
+        hasCodeChanged = mainCode != code;
+      } else {
+        // no code on chain
+        hasCodeChanged = true;
+      }
+      setFilesDetails(
+        filesDetails.set(widgetName, {
+          codeChangesPresent: hasCodeChanged,
+          isDraft: filesDetails.get(widgetName)?.isDraft,
+        })
+      );
+    };
+    fetchCodeAndDraftOnChain();
+  };
+
+  useEffect(() => {
+    if (!files) {
+      return;
+    }
+
+    checkDrafts();
+    checkHasCodeChange();
+  }, [files]);
+
+  useEffect(() => {
+    checkHasCodeChangeSingleFile(code);
+  }, [code]);
 
   useEffect(() => {
     ls.set(WidgetPropsKey, widgetProps);
@@ -162,6 +368,7 @@ export default function EditorPage(props) {
 
   const openFile = useCallback(
     (path, code) => {
+      setCodeChangesPresent();
       setPath(path);
       addToFiles(path);
       setMetadata(undefined);
@@ -194,6 +401,30 @@ export default function EditorPage(props) {
     return { type, name };
   }, []);
 
+  const openDraft = useCallback(
+    (widgetName) => {
+      if (!near) {
+        return;
+      }
+      const widgetSrc = `${accountId}/widget/${widgetName}/branch/draft`;
+
+      const c = () => {
+        const draftCode = cache.socialGet(
+          near,
+          widgetSrc,
+          false,
+          undefined,
+          undefined,
+          c
+        );
+        openFile(toPath(Filetype.Widget, widgetSrc), draftCode || code);
+      };
+
+      c();
+    },
+    [accountId, openFile, toPath, near, cache]
+  );
+
   const loadFile = useCallback(
     (nameOrPath) => {
       if (!near) {
@@ -213,7 +444,7 @@ export default function EditorPage(props) {
           c
         );
         if (code) {
-          const name = widgetSrc.split("/").slice(2).join("/");
+          // const name = widgetSrc.split("/").slice(2).join("/");
           openFile(toPath(Filetype.Widget, widgetSrc), code);
         }
       };
@@ -343,11 +574,61 @@ export default function EditorPage(props) {
     [setLayout, tab, setTab]
   );
 
-  const widgetName = path?.name;
+  const widgetName = path?.name?.split("/")[0];
+  const widgetPathName = path?.name;
+  // const isDraft = path?.name?.split("/")[2] === "draft";
 
-  const commitButton = (
-    <CommitButton
+  const widgetPath = `${accountId}/${path?.type}/${path?.name}`;
+  const jpath = JSON.stringify(path);
+
+  const createOpenDraftButton = (
+    <button
       className="btn btn-primary"
+      onClick={(e) => {
+        openDraft(widgetName);
+      }}
+    >
+      Open a Draft Version
+    </button>
+  );
+
+  const publishDraftAsMainButton = (
+    <CommitButton
+      className={`btn btn-primary`}
+      disabled={!widgetName}
+      near={near}
+      data={{
+        widget: {
+          [widgetName]: {
+            "": code,
+            metadata,
+            branch: {
+              draft: null,
+            },
+          },
+        },
+      }}
+    >
+      Publish
+    </CommitButton>
+  );
+
+  const saveDraftButton = (
+    <button
+      className="btn btn-outline-primary me-2"
+      disabled={!widgetName}
+      onClick={(e) => {
+        e.preventDefault();
+        setShowSaveDraftModal(true);
+      }}
+    >
+      Save Version
+    </button>
+  );
+
+  const publishButton = (
+    <CommitButton
+      className={`btn btn-primary`}
       disabled={!widgetName}
       near={near}
       data={{
@@ -359,339 +640,554 @@ export default function EditorPage(props) {
         },
       }}
     >
-      Save Widget
+      Publish
     </CommitButton>
   );
 
-  const widgetPath = `${accountId}/${path?.type}/${path?.name}`;
-  const jpath = JSON.stringify(path);
+  const renderPreviewButton = (
+    <button
+      className="btn btn-outline-primary"
+      onClick={() => {
+        setRenderCode(code);
+        if (layout === Layout.Tabs) {
+          setTab(Tab.Widget);
+        }
+      }}
+    >
+      Render Preview
+    </button>
+  );
+
+  const openCreateButton = (
+    <button
+      className="btn btn-success ms-2"
+      onClick={() => setShowAddModal(true)}
+      style={{
+        fontSize: "20px",
+        height: "40px",
+        lineHeight: "38px",
+        paddingTop: "0",
+        marginTop: "0",
+      }}
+    >
+      <i className="bi bi-plus"></i>
+    </button>
+  );
+
+  const renameButton = (
+    <button
+      className="btn btn-outline-success ms-2"
+      style={{ height: "40px" }}
+      onClick={() => {
+        setShowRenameModal(true);
+      }}
+    >
+      <i className="bi bi-pen"></i>
+    </button>
+  );
+
+  const openInNewTabButton = (
+    <a
+      className="btn me-2 btn-outline-secondary"
+      style={{ height: "38px" }}
+      href={`#/${widgetPath}`}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      Open Component
+    </a>
+  );
+
+  const forkButton = (
+    <button
+      className="btn btn-outline-primary me-2"
+      onClick={() => {
+        const forkName = widgetName + "-fork";
+        openFile(toPath(Filetype.Widget, forkName), code);
+      }}
+    >
+      Fork
+    </button>
+  );
 
   return (
-    <>
-      <VsCodeBanner />
-      <div className="container-fluid mt-1">
-        <RenameModal
-          key={`rename-modal-${jpath}`}
-          show={showRenameModal}
-          name={path?.name}
-          onRename={(newName) => renameFile(newName, code)}
-          onHide={() => setShowRenameModal(false)}
-        />
-        <OpenModal
-          show={showOpenModal}
-          onOpen={(newName) => loadFile(newName)}
-          onNew={(newName) =>
-            newName
-              ? openFile(toPath(Filetype.Widget, newName), DefaultEditorCode)
-              : createFile(Filetype.Widget)
-          }
-          onHide={() => setShowOpenModal(false)}
-        />
-        <div className="mb-3">
-          <Nav
-            variant="pills mb-1"
-            activeKey={jpath}
-            onSelect={(key) => openFile(JSON.parse(key))}
-          >
-            {files?.map((p, idx) => {
-              const jp = JSON.stringify(p);
-              return (
-                <Nav.Item key={jp}>
-                  <Nav.Link className="text-decoration-none" eventKey={jp}>
-                    {p.name}
-                    <button
-                      className={`btn btn-sm border-0 py-0 px-1 ms-1 rounded-circle ${
-                        jp === jpath
-                          ? "btn-outline-light"
-                          : "btn-outline-secondary"
-                      }`}
-                      onClick={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        removeFromFiles(p);
-                        if (jp === jpath) {
-                          if (files.length > 1) {
-                            openFile(files[idx - 1] || files[idx + 1]);
-                          } else {
-                            createFile(Filetype.Widget);
-                          }
-                        }
-                      }}
-                    >
-                      <i className="bi bi-x"></i>
-                    </button>
-                  </Nav.Link>
-                </Nav.Item>
-              );
-            })}
-            <Nav.Item>
-              <Nav.Link
-                className="text-decoration-none"
-                onClick={() => setShowOpenModal(true)}
-              >
-                <i className="bi bi-file-earmark-plus"></i> Add
-              </Nav.Link>
-            </Nav.Item>
-          </Nav>
-          {props.widgets.editorComponentSearch && (
-            <div>
-              {/* We use the component search widget as a VM entry point to add a TOS check wrapper.
-                  It does not need to be this component, just some <Widget /> on the page */}
-              <Widget
-                src={props.tos.checkComponentPath}
-                props={{
-                  logOut: props.logOut,
-                  tosName: props.tos.contentComponentPath,
-                  targetComponent: props.widgets.editorComponentSearch,
-                  targetProps: useMemo(
-                    () => ({
-                      extraButtons: ({ widgetName, widgetPath, onHide }) => (
-                        <OverlayTrigger
-                          placement="auto"
-                          overlay={
-                            <Tooltip>
-                              Open "{widgetName}" component in the editor
-                            </Tooltip>
-                          }
-                        >
-                          <button
-                            className="btn btn-outline-primary"
-                            onClick={(e) => {
-                              e.preventDefault();
-                              loadFile(widgetPath);
-                              onHide && onHide();
-                            }}
-                          >
-                            Open
-                          </button>
-                        </OverlayTrigger>
-                      ),
-                    }),
-                    [loadFile]
-                  ),
-                }}
-              />
-            </div>
-          )}
-        </div>
-        <div className="d-flex align-content-start">
-          <div className="me-2">
-            <div
-              className="btn-group-vertical"
-              role="group"
-              aria-label="Layout selection"
+    <div className="container-fluid mt-1">
+      <RenameModal
+        key={`rename-modal-${jpath}`}
+        show={showRenameModal}
+        name={path?.name}
+        onRename={(newName) => renameFile(newName, code)}
+        onHide={() => setShowRenameModal(false)}
+      />
+      <OpenModal
+        show={showOpenModal}
+        onOpen={(newName) => loadFile(newName)}
+        onNew={(newName) =>
+          newName
+            ? openFile(toPath(Filetype.Widget, newName), DefaultEditorCode)
+            : createFile(Filetype.Widget)
+        }
+        onHide={() => setShowOpenModal(false)}
+      />
+      <AddModal
+        show={showAddModal}
+        onOpen={() => (setShowAddModal(false), setShowOpenModal(true))}
+        onNew={() => (setShowAddModal(false), setShowCreateModal(true))}
+        onHide={() => setShowAddModal(false)}
+      />
+      <CreateModal
+        show={showCreateModal}
+        onOpen={(newName) => loadFile(newName)}
+        onNew={(newName) =>
+          newName
+            ? openFile(toPath(Filetype.Widget, newName), DefaultEditorCode)
+            : createFile(Filetype.Widget)
+        }
+        onHide={() => setShowCreateModal(false)}
+      />
+      <SaveDraftModal
+        show={showSaveDraftModal}
+        onHide={() => setShowSaveDraftModal(false)}
+        near={near}
+        widgetPath={widgetPath}
+        widgetName={widgetName}
+        code={code}
+      />
+      <div className="mb-3">
+        <div className="w-100 d-flex " style={{ flexWrap: "nowrap" }}>
+          <div className="d-flex" style={{ flexWrap: "wrap" }}>
+            <Nav
+              variant="pills mb-5 mt-3"
+              activeKey={jpath}
+              onSelect={(key) => openFile(JSON.parse(key))}
             >
-              <input
-                type="radio"
-                className="btn-check"
-                name="layout-radio"
-                id="layout-tabs"
-                autoComplete="off"
-                checked={layout === Layout.Tabs}
-                onChange={onLayoutChange}
-                value={Layout.Tabs}
-                title={"Set layout to Tabs mode"}
-              />
-              <label className="btn btn-outline-secondary" htmlFor="layout-tabs">
-                <i className="bi bi-square" />
-              </label>
+              {files?.map((p, idx) => {
+                const jp = JSON.stringify(p);
+                const widgetName = p?.name?.split("/")[0];
+                const { codeChangesPresent, isDraft } =
+                  filesDetails.get(widgetName) || {};
 
-              <input
-                type="radio"
-                className="btn-check"
-                name="layout-radio"
-                id="layout-split"
-                autoComplete="off"
-                checked={layout === Layout.Split}
-                value={Layout.Split}
-                title={"Set layout to Split mode"}
-                onChange={onLayoutChange}
-              />
-              <label className="btn btn-outline-secondary" htmlFor="layout-split">
-                <i className="bi bi-layout-split" />
-              </label>
-            </div>
-          </div>
-          <div className="flex-grow-1">
-            <div className="row">
-              <div className={layoutClass}>
-                <ul className={`nav nav-tabs mb-2`}>
-                  <li className="nav-item">
-                    <button
-                      className={`nav-link ${tab === Tab.Editor ? "active" : ""}`}
-                      aria-current="page"
-                      onClick={() => setTab(Tab.Editor)}
-                    >
-                      Editor
-                    </button>
-                  </li>
-                  <li className="nav-item">
-                    <button
-                      className={`nav-link ${tab === Tab.Props ? "active" : ""}`}
-                      aria-current="page"
-                      onClick={() => setTab(Tab.Props)}
-                    >
-                      Props
-                    </button>
-                  </li>
-                  {props.widgets.widgetMetadataEditor && (
-                    <li className="nav-item">
-                      <button
-                        className={`nav-link ${
-                          tab === Tab.Metadata ? "active" : ""
-                        }`}
-                        aria-current="page"
-                        onClick={() => setTab(Tab.Metadata)}
+                return (
+                  <Nav.Item key={jp}>
+                    <TopMenu>
+                      <Nav.Link
+                        className="text-decoration-none d-flex "
+                        eventKey={jp}
                       >
-                        Metadata
-                      </button>
-                    </li>
-                  )}
-                  {layout === Layout.Tabs && (
-                    <li className="nav-item">
+                        <div className="d-flex">
+                          {/* X1 */}
+                          {isDraft && <div className="draft">Draft</div>}
+                          <div>{widgetName}</div>
+                          {codeChangesPresent && <div className="dot"></div>}
+                        </div>
+                        <button
+                          className={`close btn btn-lg border-0 py-0 px-1 ms-1 rounded-circle btn-outline-secondary`}
+                          style={{
+                            marginTop: "-3px",
+                            marginBottom: "0px",
+                          }}
+                          onClick={(e) => {
+                            e.preventDefault();
+                            e.stopPropagation();
+                            removeFromFiles(p);
+                            if (jp === jpath) {
+                              if (files.length > 1) {
+                                openFile(files[idx - 1] || files[idx + 1]);
+                              } else {
+                                createFile(Filetype.Widget);
+                              }
+                            }
+                          }}
+                        >
+                          <i className="bi bi-x"></i>
+                        </button>
+                      </Nav.Link>
+                    </TopMenu>
+                  </Nav.Item>
+                );
+              })}
+              <Nav.Item className="me-1">
+                {openCreateButton}
+                {renameButton}
+              </Nav.Item>
+            </Nav>
+          </div>
+          <div
+            className="d-flex ms-auto"
+            style={{ minWidth: "280px", flexWrap: "wrap" }}
+          >
+            <Nav
+              variant="pills mb-5 mt-3 ms-auto"
+              activeKey={jpath}
+              onSelect={(key) => openFile(JSON.parse(key))}
+            >
+              <Nav.Item className="">
+                {saveDraftButton}
+                {forkButton}
+
+                {filesDetails.get(widgetName)?.isDraft
+                  ? !path?.unnamed && publishDraftAsMainButton
+                  : !path?.unnamed && publishButton}
+              </Nav.Item>
+            </Nav>
+          </div>
+        </div>
+
+        {props.widgets.editorComponentSearch && (
+          <div>
+            <Widget
+              src={props.widgets.editorComponentSearch}
+              props={useMemo(
+                () => ({
+                  extraButtons: ({ widgetName, widgetPath, onHide }) => (
+                    <OverlayTrigger
+                      placement="auto"
+                      overlay={
+                        <Tooltip>
+                          Open "{widgetName}" component in the editor
+                        </Tooltip>
+                      }
+                    >
                       <button
-                        className={`nav-link ${
-                          tab === Tab.Widget ? "active" : ""
-                        }`}
-                        aria-current="page"
-                        onClick={() => {
-                          setRenderCode(code);
-                          setTab(Tab.Widget);
+                        className="btn btn-outline-primary"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          loadFile(widgetPath);
+                          onHide && onHide();
                         }}
                       >
-                        Widget Preview
+                        Open
+                      </button>
+                    </OverlayTrigger>
+                  ),
+                }),
+                [loadFile]
+              )}
+            />
+          </div>
+        )}
+      </div>
+      <div className="d-flex align-content-start">
+        <div className="flex-grow-1">
+          <div className="row">
+            <div className={layoutClass}>
+              <div
+                style={{
+                  display: "flex",
+                }}
+              >
+                <div>
+                  <ul
+                    className={`nav nav-tabs`}
+                    style={{
+                      borderBottom: "0px",
+                      marginTop: "9px",
+                    }}
+                  >
+                    <li className="nav-item">
+                      <button
+                        className={`nav-link ${
+                          tab === Tab.Editor ? "active" : "text-secondary"
+                        }`}
+                        aria-current="page"
+                        onClick={() => setTab(Tab.Editor)}
+                      >
+                        Component
                       </button>
                     </li>
-                  )}
-                </ul>
-
-                <div className={`${tab === Tab.Editor ? "" : "visually-hidden"}`}>
-                  <div className="form-control mb-3" style={{ height: "70vh" }}>
-                    <Editor
-                      value={code}
-                      path={widgetPath}
-                      defaultLanguage="javascript"
-                      onChange={(code) => updateCode(path, code)}
-                      wrapperProps={{
-                        onBlur: () => reformat(path, code),
-                      }}
-                    />
-                  </div>
-                  <div className="mb-3 d-flex gap-2 flex-wrap">
-                    <button
-                      className="btn btn-success"
-                      onClick={() => {
-                        setRenderCode(code);
-                        if (layout === Layout.Tabs) {
-                          setTab(Tab.Widget);
-                        }
-                      }}
-                    >
-                      Render preview
-                    </button>
-                    {!path?.unnamed && commitButton}
-                    <button
-                      className={`btn ${
-                        path?.unnamed ? "btn-primary" : "btn-secondary"
-                      }`}
-                      onClick={() => {
-                        setShowRenameModal(true);
-                      }}
-                    >
-                      Rename {path?.type}
-                    </button>
-                    {path && accountId && (
-                      <a
-                        className="btn btn-outline-primary"
-                        href={`#/${widgetPath}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
+                    <li className="nav-item">
+                      <button
+                        className={`nav-link ${
+                          tab === Tab.Props ? "active" : "text-secondary"
+                        }`}
+                        aria-current="page"
+                        onClick={() => setTab(Tab.Props)}
                       >
-                        Open Component in a new tab
-                      </a>
+                        Props
+                      </button>
+                    </li>
+                    {props.widgets.widgetMetadataEditor && (
+                      <li className="nav-item">
+                        <button
+                          className={`nav-link ${
+                            tab === Tab.Metadata ? "active" : "text-secondary"
+                          }`}
+                          aria-current="page"
+                          onClick={() => setTab(Tab.Metadata)}
+                        >
+                          Metadata
+                        </button>
+                      </li>
                     )}
-                  </div>
+                    {layout === Layout.Tabs && (
+                      <li className="nav-item">
+                        <button
+                          className={`nav-link ${
+                            tab === Tab.Widget ? "active" : ""
+                          }`}
+                          aria-current="page"
+                          onClick={() => {
+                            setRenderCode(code);
+                            setTab(Tab.Widget);
+                          }}
+                        >
+                          Component Preview
+                        </button>
+                      </li>
+                    )}
+                  </ul>
                 </div>
-                <div className={`${tab === Tab.Props ? "" : "visually-hidden"}`}>
-                  <div className="form-control" style={{ height: "70vh" }}>
-                    <Editor
-                      value={widgetProps}
-                      defaultLanguage="json"
-                      onChange={(props) => setWidgetProps(props)}
-                      wrapperProps={{
-                        onBlur: () => reformatProps(widgetProps),
+                {layout === Layout.Tabs && (
+                  <div className="ms-auto d-flex">
+                    {path && accountId && openInNewTabButton}
+                    <div
+                      className="btn-group"
+                      role="group"
+                      aria-label="Layout selection"
+                      style={{
+                        height: "38px",
                       }}
-                    />
+                    >
+                      <input
+                        type="radio"
+                        className="btn-check"
+                        name="layout-radio"
+                        id="layout-tabs"
+                        autoComplete="off"
+                        checked={layout === Layout.Tabs}
+                        onChange={onLayoutChange}
+                        value={Layout.Tabs}
+                        title={"Set layout to Tabs mode"}
+                      />
+                      <label
+                        className="btn btn-outline-secondary"
+                        htmlFor="layout-tabs"
+                      >
+                        <i className="bi bi-square" />
+                      </label>
+                      <input
+                        type="radio"
+                        className="btn-check"
+                        name="layout-radio"
+                        id="layout-split"
+                        autoComplete="off"
+                        checked={layout === Layout.Split}
+                        value={Layout.Split}
+                        title={"Set layout to Split mode"}
+                        onChange={onLayoutChange}
+                      />
+                      <label
+                        className="btn btn-outline-secondary"
+                        htmlFor="layout-split"
+                      >
+                        <i className="bi bi-layout-split" />
+                      </label>
+                    </div>
                   </div>
-                  <div className=" mb-3">^^ Props for debugging (in JSON)</div>
-                  {propsError && (
-                    <pre className="alert alert-danger">{propsError}</pre>
-                  )}
-                </div>
+                )}
+              </div>
+
+              <div className={`${tab === Tab.Editor ? "" : "visually-hidden"}`}>
                 <div
-                  className={`${
-                    tab === Tab.Metadata && props.widgets.widgetMetadataEditor
-                      ? ""
-                      : "visually-hidden"
-                  }`}
+                  className="form-control mb-3"
+                  style={{ height: "70vh", borderTopLeftRadius: "0px" }}
                 >
-                  <div className="mb-3">
-                    <Widget
-                      src={props.widgets.widgetMetadataEditor}
-                      key={`metadata-editor-${jpath}`}
-                      props={useMemo(
-                        () => ({
-                          widgetPath,
-                          onChange: setMetadata,
-                        }),
-                        [widgetPath]
-                      )}
-                    />
-                  </div>
-                  <div className="mb-3">{commitButton}</div>
+                  <Editor
+                    value={code}
+                    path={widgetPath}
+                    defaultLanguage="javascript"
+                    onChange={(code) => updateCode(path, code)}
+                    wrapperProps={{
+                      onBlur: () => reformat(path, code),
+                    }}
+                  />
                 </div>
+                <div className="mb-3 d-flex gap-2 flex-wrap"></div>
+              </div>
+              <div className={`${tab === Tab.Props ? "" : "visually-hidden"}`}>
+                <div className="form-control" style={{ height: "70vh" }}>
+                  <Editor
+                    value={widgetProps}
+                    defaultLanguage="json"
+                    onChange={(props) => setWidgetProps(props)}
+                    wrapperProps={{
+                      onBlur: () => reformatProps(widgetProps),
+                    }}
+                  />
+                </div>
+                <div className=" mb-3">^^ Props for debugging (in JSON)</div>
+                {propsError && (
+                  <pre className="alert alert-danger">{propsError}</pre>
+                )}
               </div>
               <div
                 className={`${
-                  tab === Tab.Widget ||
-                  (layout === Layout.Split && tab !== Tab.Metadata)
-                    ? layoutClass
+                  tab === Tab.Metadata && props.widgets.widgetMetadataEditor
+                    ? ""
                     : "visually-hidden"
                 }`}
               >
-                <div className="container">
-                  <div className="row">
-                    <div className="d-inline-block position-relative overflow-hidden">
-                      {renderCode ? (
-                        <Widget
-                          key={`preview-${jpath}`}
-                          code={renderCode}
-                          props={parsedWidgetProps}
-                        />
-                      ) : (
-                        'Click "Render preview" button to render the widget'
-                      )}
+                <div
+                  className="mb-3"
+                  style={{
+                    paddingTop: "20px",
+                    padding: "20px",
+                    border: "1px solid rgb(206, 212, 218)",
+                    appearance: "none",
+                    borderRadius: "0.375rem",
+                    height: "70vh",
+                  }}
+                >
+                  <Widget
+                    src={props.widgets.widgetMetadataEditor}
+                    key={`metadata-editor-${jpath}`}
+                    props={useMemo(
+                      () => ({
+                        widgetPath,
+                        onChange: setMetadata,
+                      }),
+                      [widgetPath]
+                    )}
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              className={`${
+                tab === Tab.Widget ||
+                (layout === Layout.Split && tab !== Tab.Metadata)
+                  ? layoutClass
+                  : "visually-hidden"
+              }`}
+            >
+              <div style={{ height: "100%", height: "70vh" }}>
+                {tab === Tab.Widget || (
+                  <div
+                    style={{
+                      height: "38px",
+                      display: "flex",
+                      marginBottom: "12px",
+                      justifyContent: "end",
+                    }}
+                  >
+                    {tab === Tab.Widget || (
+                      <>
+                        {renderCode && (
+                          <div className="d-flex justify-content-end me-2">
+                            {renderPreviewButton}
+                          </div>
+                        )}
+                        {path && accountId && openInNewTabButton}
+                        <div
+                          className="btn-group"
+                          role="group"
+                          aria-label="Layout selection"
+                        >
+                          <input
+                            type="radio"
+                            className="btn-check"
+                            name="layout-radio"
+                            id="layout-tabs"
+                            autoComplete="off"
+                            checked={layout === Layout.Tabs}
+                            onChange={onLayoutChange}
+                            value={Layout.Tabs}
+                            title={"Set layout to Tabs mode"}
+                          />
+                          <label
+                            className="btn btn-outline-secondary"
+                            htmlFor="layout-tabs"
+                          >
+                            <i className="bi bi-square" />
+                          </label>
+
+                          <input
+                            type="radio"
+                            className="btn-check"
+                            name="layout-radio"
+                            id="layout-split"
+                            autoComplete="off"
+                            checked={layout === Layout.Split}
+                            value={Layout.Split}
+                            title={"Set layout to Split mode"}
+                            onChange={onLayoutChange}
+                          />
+                          <label
+                            className="btn btn-outline-secondary"
+                            htmlFor="layout-split"
+                          >
+                            <i className="bi bi-layout-split" />
+                          </label>
+                        </div>
+                      </>
+                    )}
+                  </div>
+                )}
+                <div
+                  className="container"
+                  style={
+                    tab === Tab.Widget
+                      ? {
+                          border: "1px solid #ced4da",
+                          appearance: "none",
+                          borderRadius: "0.375rem",
+                          height: "70vh",
+                          marginTop: "8px",
+                          maxWidth: "100%",
+                        }
+                      : {
+                          padding: "20px",
+                          border: "1px solid #ced4da",
+                          appearance: "none",
+                          borderRadius: "0.375rem",
+                          height: "70vh",
+                        }
+                  }
+                >
+                  <div className="h-100 row">
+                    <div className="d-inline-block position-relative overflow-hidden h-100">
+                      <div
+                        className="h-100"
+                        style={{
+                          height: "100%",
+                          padding: 0,
+                          margin: 0,
+                          display: "flex",
+                          alignItems: "center",
+                          justifyContent: "center",
+                        }}
+                      >
+                        {renderCode ? (
+                          <Widget
+                            key={`preview-${jpath}`}
+                            code={renderCode}
+                            props={parsedWidgetProps}
+                          />
+                        ) : (
+                          renderPreviewButton
+                        )}
+                      </div>
                     </div>
                   </div>
                 </div>
               </div>
-              <div
-                className={`${
-                  tab === Tab.Metadata ? layoutClass : "visually-hidden"
-                }`}
-              >
-                <div className="container">
-                  <div className="row">
-                    <div className="d-inline-block position-relative overflow-hidden">
-                      <Widget
-                        key={`metadata-${jpath}`}
-                        src={props.widgets.widgetMetadata}
-                        props={useMemo(
-                          () => ({ metadata, accountId, widgetName }),
-                          [metadata, accountId, widgetName]
-                        )}
-                      />
-                    </div>
+            </div>
+            <div
+              className={`${
+                tab === Tab.Metadata ? layoutClass : "visually-hidden"
+              }`}
+            >
+              <div className="container" style={{ marginTop: "50px" }}>
+                <div className="row">
+                  <div className="d-inline-block position-relative overflow-hidden">
+                    <Widget
+                      key={`metadata-${jpath}`}
+                      src={props.widgets.widgetMetadata}
+                      props={useMemo(
+                        () => ({ metadata, accountId, widgetName }),
+                        [metadata, accountId, widgetName]
+                      )}
+                    />
                   </div>
                 </div>
               </div>
@@ -699,6 +1195,6 @@ export default function EditorPage(props) {
           </div>
         </div>
       </div>
-    </>
+    </div>
   );
 }

--- a/src/pages/EditorPage.js
+++ b/src/pages/EditorPage.js
@@ -18,6 +18,7 @@ import AddModal from "../components/Editor/AddModal";
 import CreateModal from "../components/Editor/CreateModal";
 import { SaveDraftModal } from "../components/SaveDraft";
 import styled from "styled-components";
+import VsCodeBanner from "../components/Editor/VsCodeBanner";
 
 const TopMenu = styled.div`
   border-radius: 0.375rem;
@@ -711,490 +712,505 @@ export default function EditorPage(props) {
   );
 
   return (
-    <div className="container-fluid mt-1">
-      <RenameModal
-        key={`rename-modal-${jpath}`}
-        show={showRenameModal}
-        name={path?.name}
-        onRename={(newName) => renameFile(newName, code)}
-        onHide={() => setShowRenameModal(false)}
-      />
-      <OpenModal
-        show={showOpenModal}
-        onOpen={(newName) => loadFile(newName)}
-        onNew={(newName) =>
-          newName
-            ? openFile(toPath(Filetype.Widget, newName), DefaultEditorCode)
-            : createFile(Filetype.Widget)
-        }
-        onHide={() => setShowOpenModal(false)}
-      />
-      <AddModal
-        show={showAddModal}
-        onOpen={() => (setShowAddModal(false), setShowOpenModal(true))}
-        onNew={() => (setShowAddModal(false), setShowCreateModal(true))}
-        onHide={() => setShowAddModal(false)}
-      />
-      <CreateModal
-        show={showCreateModal}
-        onOpen={(newName) => loadFile(newName)}
-        onNew={(newName) =>
-          newName
-            ? openFile(toPath(Filetype.Widget, newName), DefaultEditorCode)
-            : createFile(Filetype.Widget)
-        }
-        onHide={() => setShowCreateModal(false)}
-      />
-      <SaveDraftModal
-        show={showSaveDraftModal}
-        onHide={() => setShowSaveDraftModal(false)}
-        near={near}
-        widgetPath={widgetPath}
-        widgetName={widgetName}
-        code={code}
-      />
-      <div className="mb-3">
-        <div className="w-100 d-flex " style={{ flexWrap: "nowrap" }}>
-          <div className="d-flex" style={{ flexWrap: "wrap" }}>
-            <Nav
-              variant="pills mb-5 mt-3"
-              activeKey={jpath}
-              onSelect={(key) => openFile(JSON.parse(key))}
-            >
-              {files?.map((p, idx) => {
-                const jp = JSON.stringify(p);
-                const widgetName = p?.name?.split("/")[0];
-                const { codeChangesPresent, isDraft } =
-                  filesDetails.get(widgetName) || {};
+    <>
+      <VsCodeBanner />
 
-                return (
-                  <Nav.Item key={jp}>
-                    <TopMenu>
-                      <Nav.Link
-                        className="text-decoration-none d-flex "
-                        eventKey={jp}
-                      >
-                        <div className="d-flex">
-                          {/* X1 */}
-                          {isDraft && <div className="draft">Draft</div>}
-                          <div>{widgetName}</div>
-                          {codeChangesPresent && <div className="dot"></div>}
-                        </div>
-                        <button
-                          className={`close btn btn-lg border-0 py-0 px-1 ms-1 rounded-circle btn-outline-secondary`}
-                          style={{
-                            marginTop: "-3px",
-                            marginBottom: "0px",
-                          }}
-                          onClick={(e) => {
-                            e.preventDefault();
-                            e.stopPropagation();
-                            removeFromFiles(p);
-                            if (jp === jpath) {
-                              if (files.length > 1) {
-                                openFile(files[idx - 1] || files[idx + 1]);
-                              } else {
-                                createFile(Filetype.Widget);
+      <div className="container-fluid mt-1">
+        <RenameModal
+          key={`rename-modal-${jpath}`}
+          show={showRenameModal}
+          name={path?.name}
+          onRename={(newName) => renameFile(newName, code)}
+          onHide={() => setShowRenameModal(false)}
+        />
+        <OpenModal
+          show={showOpenModal}
+          onOpen={(newName) => loadFile(newName)}
+          onNew={(newName) =>
+            newName
+              ? openFile(toPath(Filetype.Widget, newName), DefaultEditorCode)
+              : createFile(Filetype.Widget)
+          }
+          onHide={() => setShowOpenModal(false)}
+        />
+        <AddModal
+          show={showAddModal}
+          onOpen={() => (setShowAddModal(false), setShowOpenModal(true))}
+          onNew={() => (setShowAddModal(false), setShowCreateModal(true))}
+          onHide={() => setShowAddModal(false)}
+        />
+        <CreateModal
+          show={showCreateModal}
+          onOpen={(newName) => loadFile(newName)}
+          onNew={(newName) =>
+            newName
+              ? openFile(toPath(Filetype.Widget, newName), DefaultEditorCode)
+              : createFile(Filetype.Widget)
+          }
+          onHide={() => setShowCreateModal(false)}
+        />
+        <SaveDraftModal
+          show={showSaveDraftModal}
+          onHide={() => setShowSaveDraftModal(false)}
+          near={near}
+          widgetPath={widgetPath}
+          widgetName={widgetName}
+          code={code}
+        />
+        <div className="mb-3">
+          <div className="w-100 d-flex " style={{ flexWrap: "nowrap" }}>
+            <div className="d-flex" style={{ flexWrap: "wrap" }}>
+              <Nav
+                variant="pills mb-5 mt-3"
+                activeKey={jpath}
+                onSelect={(key) => openFile(JSON.parse(key))}
+              >
+                {files?.map((p, idx) => {
+                  const jp = JSON.stringify(p);
+                  const widgetName = p?.name?.split("/")[0];
+                  const { codeChangesPresent, isDraft } =
+                    filesDetails.get(widgetName) || {};
+
+                  return (
+                    <Nav.Item key={jp}>
+                      <TopMenu>
+                        <Nav.Link
+                          className="text-decoration-none d-flex "
+                          eventKey={jp}
+                        >
+                          <div className="d-flex">
+                            {/* X1 */}
+                            {isDraft && <div className="draft">Draft</div>}
+                            <div>{widgetName}</div>
+                            {codeChangesPresent && <div className="dot"></div>}
+                          </div>
+                          <button
+                            className={`close btn btn-lg border-0 py-0 px-1 ms-1 rounded-circle btn-outline-secondary`}
+                            style={{
+                              marginTop: "-3px",
+                              marginBottom: "0px",
+                            }}
+                            onClick={(e) => {
+                              e.preventDefault();
+                              e.stopPropagation();
+                              removeFromFiles(p);
+                              if (jp === jpath) {
+                                if (files.length > 1) {
+                                  openFile(files[idx - 1] || files[idx + 1]);
+                                } else {
+                                  createFile(Filetype.Widget);
+                                }
                               }
-                            }
-                          }}
-                        >
-                          <i className="bi bi-x"></i>
-                        </button>
-                      </Nav.Link>
-                    </TopMenu>
-                  </Nav.Item>
-                );
-              })}
-              <Nav.Item className="me-1">
-                {openCreateButton}
-                {renameButton}
-              </Nav.Item>
-            </Nav>
-          </div>
-          <div
-            className="d-flex ms-auto"
-            style={{ minWidth: "280px", flexWrap: "wrap" }}
-          >
-            <Nav
-              variant="pills mb-5 mt-3 ms-auto"
-              activeKey={jpath}
-              onSelect={(key) => openFile(JSON.parse(key))}
+                            }}
+                          >
+                            <i className="bi bi-x"></i>
+                          </button>
+                        </Nav.Link>
+                      </TopMenu>
+                    </Nav.Item>
+                  );
+                })}
+                <Nav.Item className="me-1">
+                  {openCreateButton}
+                  {renameButton}
+                </Nav.Item>
+              </Nav>
+            </div>
+            <div
+              className="d-flex ms-auto"
+              style={{ minWidth: "280px", flexWrap: "wrap" }}
             >
-              <Nav.Item className="">
-                {saveDraftButton}
-                {forkButton}
+              <Nav
+                variant="pills mb-5 mt-3 ms-auto"
+                activeKey={jpath}
+                onSelect={(key) => openFile(JSON.parse(key))}
+              >
+                <Nav.Item className="">
+                  {saveDraftButton}
+                  {forkButton}
 
-                {filesDetails.get(widgetName)?.isDraft
-                  ? !path?.unnamed && publishDraftAsMainButton
-                  : !path?.unnamed && publishButton}
-              </Nav.Item>
-            </Nav>
+                  {filesDetails.get(widgetName)?.isDraft
+                    ? !path?.unnamed && publishDraftAsMainButton
+                    : !path?.unnamed && publishButton}
+                </Nav.Item>
+              </Nav>
+            </div>
           </div>
-        </div>
 
-        {props.widgets.editorComponentSearch && (
-          <div>
-            <Widget
-              src={props.widgets.editorComponentSearch}
-              props={useMemo(
-                () => ({
-                  extraButtons: ({ widgetName, widgetPath, onHide }) => (
-                    <OverlayTrigger
-                      placement="auto"
-                      overlay={
-                        <Tooltip>
-                          Open "{widgetName}" component in the editor
-                        </Tooltip>
-                      }
-                    >
-                      <button
-                        className="btn btn-outline-primary"
-                        onClick={(e) => {
-                          e.preventDefault();
-                          loadFile(widgetPath);
-                          onHide && onHide();
-                        }}
-                      >
-                        Open
-                      </button>
-                    </OverlayTrigger>
+          {props.widgets.editorComponentSearch && (
+            <div>
+              {/* We use the component search widget as a VM entry point to add a TOS check wrapper.
+                It does not need to be this component, just some <Widget /> on the page */}
+              <Widget
+                src={props.tos.checkComponentPath}
+                props={{
+                  logOut: props.logOut,
+                  tosName: props.tos.contentComponentPath,
+                  targetComponent: props.widgets.editorComponentSearch,
+                  targetProps: useMemo(
+                    () => ({
+                      extraButtons: ({ widgetName, widgetPath, onHide }) => (
+                        <OverlayTrigger
+                          placement="auto"
+                          overlay={
+                            <Tooltip>
+                              Open "{widgetName}" component in the editor
+                            </Tooltip>
+                          }
+                        >
+                          <button
+                            className="btn btn-outline-primary"
+                            onClick={(e) => {
+                              e.preventDefault();
+                              loadFile(widgetPath);
+                              onHide && onHide();
+                            }}
+                          >
+                            Open
+                          </button>
+                        </OverlayTrigger>
+                      ),
+                    }),
+                    [loadFile]
                   ),
-                }),
-                [loadFile]
-              )}
-            />
-          </div>
-        )}
-      </div>
-      <div className="d-flex align-content-start">
-        <div className="flex-grow-1">
-          <div className="row">
-            <div className={layoutClass}>
-              <div
-                style={{
-                  display: "flex",
                 }}
-              >
-                <div>
-                  <ul
-                    className={`nav nav-tabs`}
-                    style={{
-                      borderBottom: "0px",
-                      marginTop: "9px",
-                    }}
-                  >
-                    <li className="nav-item">
-                      <button
-                        className={`nav-link ${
-                          tab === Tab.Editor ? "active" : "text-secondary"
-                        }`}
-                        aria-current="page"
-                        onClick={() => setTab(Tab.Editor)}
-                      >
-                        Component
-                      </button>
-                    </li>
-                    <li className="nav-item">
-                      <button
-                        className={`nav-link ${
-                          tab === Tab.Props ? "active" : "text-secondary"
-                        }`}
-                        aria-current="page"
-                        onClick={() => setTab(Tab.Props)}
-                      >
-                        Props
-                      </button>
-                    </li>
-                    {props.widgets.widgetMetadataEditor && (
-                      <li className="nav-item">
-                        <button
-                          className={`nav-link ${
-                            tab === Tab.Metadata ? "active" : "text-secondary"
-                          }`}
-                          aria-current="page"
-                          onClick={() => setTab(Tab.Metadata)}
-                        >
-                          Metadata
-                        </button>
-                      </li>
-                    )}
-                    {layout === Layout.Tabs && (
-                      <li className="nav-item">
-                        <button
-                          className={`nav-link ${
-                            tab === Tab.Widget ? "active" : ""
-                          }`}
-                          aria-current="page"
-                          onClick={() => {
-                            setRenderCode(code);
-                            setTab(Tab.Widget);
-                          }}
-                        >
-                          Component Preview
-                        </button>
-                      </li>
-                    )}
-                  </ul>
-                </div>
-                {layout === Layout.Tabs && (
-                  <div className="ms-auto d-flex">
-                    {path && accountId && openInNewTabButton}
-                    <div
-                      className="btn-group"
-                      role="group"
-                      aria-label="Layout selection"
-                      style={{
-                        height: "38px",
-                      }}
-                    >
-                      <input
-                        type="radio"
-                        className="btn-check"
-                        name="layout-radio"
-                        id="layout-tabs"
-                        autoComplete="off"
-                        checked={layout === Layout.Tabs}
-                        onChange={onLayoutChange}
-                        value={Layout.Tabs}
-                        title={"Set layout to Tabs mode"}
-                      />
-                      <label
-                        className="btn btn-outline-secondary"
-                        htmlFor="layout-tabs"
-                      >
-                        <i className="bi bi-square" />
-                      </label>
-                      <input
-                        type="radio"
-                        className="btn-check"
-                        name="layout-radio"
-                        id="layout-split"
-                        autoComplete="off"
-                        checked={layout === Layout.Split}
-                        value={Layout.Split}
-                        title={"Set layout to Split mode"}
-                        onChange={onLayoutChange}
-                      />
-                      <label
-                        className="btn btn-outline-secondary"
-                        htmlFor="layout-split"
-                      >
-                        <i className="bi bi-layout-split" />
-                      </label>
-                    </div>
-                  </div>
-                )}
-              </div>
-
-              <div className={`${tab === Tab.Editor ? "" : "visually-hidden"}`}>
+              />
+            </div>
+          )}
+        </div>
+        <div className="d-flex align-content-start">
+          <div className="flex-grow-1">
+            <div className="row">
+              <div className={layoutClass}>
                 <div
-                  className="form-control mb-3"
-                  style={{ height: "70vh", borderTopLeftRadius: "0px" }}
-                >
-                  <Editor
-                    value={code}
-                    path={widgetPath}
-                    defaultLanguage="javascript"
-                    onChange={(code) => updateCode(path, code)}
-                    wrapperProps={{
-                      onBlur: () => reformat(path, code),
-                    }}
-                  />
-                </div>
-                <div className="mb-3 d-flex gap-2 flex-wrap"></div>
-              </div>
-              <div className={`${tab === Tab.Props ? "" : "visually-hidden"}`}>
-                <div className="form-control" style={{ height: "70vh" }}>
-                  <Editor
-                    value={widgetProps}
-                    defaultLanguage="json"
-                    onChange={(props) => setWidgetProps(props)}
-                    wrapperProps={{
-                      onBlur: () => reformatProps(widgetProps),
-                    }}
-                  />
-                </div>
-                <div className=" mb-3">^^ Props for debugging (in JSON)</div>
-                {propsError && (
-                  <pre className="alert alert-danger">{propsError}</pre>
-                )}
-              </div>
-              <div
-                className={`${
-                  tab === Tab.Metadata && props.widgets.widgetMetadataEditor
-                    ? ""
-                    : "visually-hidden"
-                }`}
-              >
-                <div
-                  className="mb-3"
                   style={{
-                    paddingTop: "20px",
-                    padding: "20px",
-                    border: "1px solid rgb(206, 212, 218)",
-                    appearance: "none",
-                    borderRadius: "0.375rem",
-                    height: "70vh",
+                    display: "flex",
                   }}
                 >
-                  <Widget
-                    src={props.widgets.widgetMetadataEditor}
-                    key={`metadata-editor-${jpath}`}
-                    props={useMemo(
-                      () => ({
-                        widgetPath,
-                        onChange: setMetadata,
-                      }),
-                      [widgetPath]
-                    )}
-                  />
-                </div>
-              </div>
-            </div>
-            <div
-              className={`${
-                tab === Tab.Widget ||
-                (layout === Layout.Split && tab !== Tab.Metadata)
-                  ? layoutClass
-                  : "visually-hidden"
-              }`}
-            >
-              <div style={{ height: "100%", height: "70vh" }}>
-                {tab === Tab.Widget || (
-                  <div
-                    style={{
-                      height: "38px",
-                      display: "flex",
-                      marginBottom: "12px",
-                      justifyContent: "end",
-                    }}
-                  >
-                    {tab === Tab.Widget || (
-                      <>
-                        {renderCode && (
-                          <div className="d-flex justify-content-end me-2">
-                            {renderPreviewButton}
-                          </div>
-                        )}
-                        {path && accountId && openInNewTabButton}
-                        <div
-                          className="btn-group"
-                          role="group"
-                          aria-label="Layout selection"
+                  <div>
+                    <ul
+                      className={`nav nav-tabs`}
+                      style={{
+                        borderBottom: "0px",
+                        marginTop: "9px",
+                      }}
+                    >
+                      <li className="nav-item">
+                        <button
+                          className={`nav-link ${
+                            tab === Tab.Editor ? "active" : "text-secondary"
+                          }`}
+                          aria-current="page"
+                          onClick={() => setTab(Tab.Editor)}
                         >
-                          <input
-                            type="radio"
-                            className="btn-check"
-                            name="layout-radio"
-                            id="layout-tabs"
-                            autoComplete="off"
-                            checked={layout === Layout.Tabs}
-                            onChange={onLayoutChange}
-                            value={Layout.Tabs}
-                            title={"Set layout to Tabs mode"}
-                          />
-                          <label
-                            className="btn btn-outline-secondary"
-                            htmlFor="layout-tabs"
+                          Component
+                        </button>
+                      </li>
+                      <li className="nav-item">
+                        <button
+                          className={`nav-link ${
+                            tab === Tab.Props ? "active" : "text-secondary"
+                          }`}
+                          aria-current="page"
+                          onClick={() => setTab(Tab.Props)}
+                        >
+                          Props
+                        </button>
+                      </li>
+                      {props.widgets.widgetMetadataEditor && (
+                        <li className="nav-item">
+                          <button
+                            className={`nav-link ${
+                              tab === Tab.Metadata ? "active" : "text-secondary"
+                            }`}
+                            aria-current="page"
+                            onClick={() => setTab(Tab.Metadata)}
                           >
-                            <i className="bi bi-square" />
-                          </label>
-
-                          <input
-                            type="radio"
-                            className="btn-check"
-                            name="layout-radio"
-                            id="layout-split"
-                            autoComplete="off"
-                            checked={layout === Layout.Split}
-                            value={Layout.Split}
-                            title={"Set layout to Split mode"}
-                            onChange={onLayoutChange}
-                          />
-                          <label
-                            className="btn btn-outline-secondary"
-                            htmlFor="layout-split"
+                            Metadata
+                          </button>
+                        </li>
+                      )}
+                      {layout === Layout.Tabs && (
+                        <li className="nav-item">
+                          <button
+                            className={`nav-link ${
+                              tab === Tab.Widget ? "active" : ""
+                            }`}
+                            aria-current="page"
+                            onClick={() => {
+                              setRenderCode(code);
+                              setTab(Tab.Widget);
+                            }}
                           >
-                            <i className="bi bi-layout-split" />
-                          </label>
-                        </div>
-                      </>
-                    )}
+                            Component Preview
+                          </button>
+                        </li>
+                      )}
+                    </ul>
                   </div>
-                )}
-                <div
-                  className="container"
-                  style={
-                    tab === Tab.Widget
-                      ? {
-                          border: "1px solid #ced4da",
-                          appearance: "none",
-                          borderRadius: "0.375rem",
-                          height: "70vh",
-                          marginTop: "8px",
-                          maxWidth: "100%",
-                        }
-                      : {
-                          padding: "20px",
-                          border: "1px solid #ced4da",
-                          appearance: "none",
-                          borderRadius: "0.375rem",
-                          height: "70vh",
-                        }
-                  }
-                >
-                  <div className="h-100 row">
-                    <div className="d-inline-block position-relative overflow-hidden h-100">
+                  {layout === Layout.Tabs && (
+                    <div className="ms-auto d-flex">
+                      {path && accountId && openInNewTabButton}
                       <div
-                        className="h-100"
+                        className="btn-group"
+                        role="group"
+                        aria-label="Layout selection"
                         style={{
-                          height: "100%",
-                          padding: 0,
-                          margin: 0,
-                          display: "flex",
-                          alignItems: "center",
-                          justifyContent: "center",
+                          height: "38px",
                         }}
                       >
-                        {renderCode ? (
-                          <Widget
-                            key={`preview-${jpath}`}
-                            code={renderCode}
-                            props={parsedWidgetProps}
-                          />
-                        ) : (
-                          renderPreviewButton
-                        )}
+                        <input
+                          type="radio"
+                          className="btn-check"
+                          name="layout-radio"
+                          id="layout-tabs"
+                          autoComplete="off"
+                          checked={layout === Layout.Tabs}
+                          onChange={onLayoutChange}
+                          value={Layout.Tabs}
+                          title={"Set layout to Tabs mode"}
+                        />
+                        <label
+                          className="btn btn-outline-secondary"
+                          htmlFor="layout-tabs"
+                        >
+                          <i className="bi bi-square" />
+                        </label>
+                        <input
+                          type="radio"
+                          className="btn-check"
+                          name="layout-radio"
+                          id="layout-split"
+                          autoComplete="off"
+                          checked={layout === Layout.Split}
+                          value={Layout.Split}
+                          title={"Set layout to Split mode"}
+                          onChange={onLayoutChange}
+                        />
+                        <label
+                          className="btn btn-outline-secondary"
+                          htmlFor="layout-split"
+                        >
+                          <i className="bi bi-layout-split" />
+                        </label>
                       </div>
                     </div>
-                  </div>
+                  )}
                 </div>
-              </div>
-            </div>
-            <div
-              className={`${
-                tab === Tab.Metadata ? layoutClass : "visually-hidden"
-              }`}
-            >
-              <div className="container" style={{ marginTop: "50px" }}>
-                <div className="row">
-                  <div className="d-inline-block position-relative overflow-hidden">
+
+                <div
+                  className={`${tab === Tab.Editor ? "" : "visually-hidden"}`}
+                >
+                  <div
+                    className="form-control mb-3"
+                    style={{ height: "70vh", borderTopLeftRadius: "0px" }}
+                  >
+                    <Editor
+                      value={code}
+                      path={widgetPath}
+                      defaultLanguage="javascript"
+                      onChange={(code) => updateCode(path, code)}
+                      wrapperProps={{
+                        onBlur: () => reformat(path, code),
+                      }}
+                    />
+                  </div>
+                  <div className="mb-3 d-flex gap-2 flex-wrap"></div>
+                </div>
+                <div
+                  className={`${tab === Tab.Props ? "" : "visually-hidden"}`}
+                >
+                  <div className="form-control" style={{ height: "70vh" }}>
+                    <Editor
+                      value={widgetProps}
+                      defaultLanguage="json"
+                      onChange={(props) => setWidgetProps(props)}
+                      wrapperProps={{
+                        onBlur: () => reformatProps(widgetProps),
+                      }}
+                    />
+                  </div>
+                  <div className=" mb-3">^^ Props for debugging (in JSON)</div>
+                  {propsError && (
+                    <pre className="alert alert-danger">{propsError}</pre>
+                  )}
+                </div>
+                <div
+                  className={`${
+                    tab === Tab.Metadata && props.widgets.widgetMetadataEditor
+                      ? ""
+                      : "visually-hidden"
+                  }`}
+                >
+                  <div
+                    className="mb-3"
+                    style={{
+                      paddingTop: "20px",
+                      padding: "20px",
+                      border: "1px solid rgb(206, 212, 218)",
+                      appearance: "none",
+                      borderRadius: "0.375rem",
+                      height: "70vh",
+                    }}
+                  >
                     <Widget
-                      key={`metadata-${jpath}`}
-                      src={props.widgets.widgetMetadata}
+                      src={props.widgets.widgetMetadataEditor}
+                      key={`metadata-editor-${jpath}`}
                       props={useMemo(
-                        () => ({ metadata, accountId, widgetName }),
-                        [metadata, accountId, widgetName]
+                        () => ({
+                          widgetPath,
+                          onChange: setMetadata,
+                        }),
+                        [widgetPath]
                       )}
                     />
                   </div>
                 </div>
               </div>
+              <div
+                className={`${
+                  tab === Tab.Widget ||
+                  (layout === Layout.Split && tab !== Tab.Metadata)
+                    ? layoutClass
+                    : "visually-hidden"
+                }`}
+              >
+                <div style={{ height: "100%", height: "70vh" }}>
+                  {tab === Tab.Widget || (
+                    <div
+                      style={{
+                        height: "38px",
+                        display: "flex",
+                        marginBottom: "12px",
+                        justifyContent: "end",
+                      }}
+                    >
+                      {tab === Tab.Widget || (
+                        <>
+                          {renderCode && (
+                            <div className="d-flex justify-content-end me-2">
+                              {renderPreviewButton}
+                            </div>
+                          )}
+                          {path && accountId && openInNewTabButton}
+                          <div
+                            className="btn-group"
+                            role="group"
+                            aria-label="Layout selection"
+                          >
+                            <input
+                              type="radio"
+                              className="btn-check"
+                              name="layout-radio"
+                              id="layout-tabs"
+                              autoComplete="off"
+                              checked={layout === Layout.Tabs}
+                              onChange={onLayoutChange}
+                              value={Layout.Tabs}
+                              title={"Set layout to Tabs mode"}
+                            />
+                            <label
+                              className="btn btn-outline-secondary"
+                              htmlFor="layout-tabs"
+                            >
+                              <i className="bi bi-square" />
+                            </label>
+
+                            <input
+                              type="radio"
+                              className="btn-check"
+                              name="layout-radio"
+                              id="layout-split"
+                              autoComplete="off"
+                              checked={layout === Layout.Split}
+                              value={Layout.Split}
+                              title={"Set layout to Split mode"}
+                              onChange={onLayoutChange}
+                            />
+                            <label
+                              className="btn btn-outline-secondary"
+                              htmlFor="layout-split"
+                            >
+                              <i className="bi bi-layout-split" />
+                            </label>
+                          </div>
+                        </>
+                      )}
+                    </div>
+                  )}
+                  <div
+                    className="container"
+                    style={
+                      tab === Tab.Widget
+                        ? {
+                            border: "1px solid #ced4da",
+                            appearance: "none",
+                            borderRadius: "0.375rem",
+                            height: "70vh",
+                            marginTop: "8px",
+                            maxWidth: "100%",
+                          }
+                        : {
+                            padding: "20px",
+                            border: "1px solid #ced4da",
+                            appearance: "none",
+                            borderRadius: "0.375rem",
+                            height: "70vh",
+                          }
+                    }
+                  >
+                    <div className="h-100 row">
+                      <div className="d-inline-block position-relative overflow-hidden h-100">
+                        <div
+                          className="h-100"
+                          style={{
+                            height: "100%",
+                            padding: 0,
+                            margin: 0,
+                            display: "flex",
+                            alignItems: "center",
+                            justifyContent: "center",
+                          }}
+                        >
+                          {renderCode ? (
+                            <Widget
+                              key={`preview-${jpath}`}
+                              code={renderCode}
+                              props={parsedWidgetProps}
+                            />
+                          ) : (
+                            renderPreviewButton
+                          )}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div
+                className={`${
+                  tab === Tab.Metadata ? layoutClass : "visually-hidden"
+                }`}
+              >
+                <div className="container" style={{ marginTop: "50px" }}>
+                  <div className="row">
+                    <div className="d-inline-block position-relative overflow-hidden">
+                      <Widget
+                        key={`metadata-${jpath}`}
+                        src={props.widgets.widgetMetadata}
+                        props={useMemo(
+                          () => ({ metadata, accountId, widgetName }),
+                          [metadata, accountId, widgetName]
+                        )}
+                      />
+                    </div>
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/src/pages/EditorPage.js
+++ b/src/pages/EditorPage.js
@@ -317,6 +317,48 @@ export default function EditorPage(props) {
   }, [code]);
 
   useEffect(() => {
+    if (files) {
+      files.forEach(f => {
+        const widgetSrc = `${accountId}/widget/${f.name}/**`;
+        const fetchCodeAndDraftOnChain = () => {
+          const widgetCode = cache.socialGet(
+            near,
+            widgetSrc,
+            false,
+            undefined,
+            undefined,
+            fetchCodeAndDraftOnChain
+          );
+
+          const mainCode = widgetCode?.[""];
+          const draft = widgetCode?.branch?.draft?.[""];
+          const isDraft = (!draft && !mainCode) || draft;  
+          const path = f;
+
+          cache
+          .asyncLocalStorageGet(StorageDomain, {
+            path,
+            type: StorageType.Code,
+          })
+          .then(({ code }) => {
+            let hasCodeChanged;
+            if (draft) {
+              hasCodeChanged = draft != code;
+            } else if (mainCode) {
+              hasCodeChanged = mainCode != code;
+            } else {
+              // no code on chain
+              hasCodeChanged = true;
+            }
+            setFilesDetails(filesDetails.set(f.name, {codeChangesPresent: hasCodeChanged, isDraft}));
+          })
+        }
+        fetchCodeAndDraftOnChain();
+      });
+    }
+  }, [code, files]);
+
+  useEffect(() => {
     ls.set(WidgetPropsKey, widgetProps);
     try {
       const parsedWidgetProps = JSON.parse(widgetProps);

--- a/src/pages/EditorPage.js
+++ b/src/pages/EditorPage.js
@@ -626,6 +626,16 @@ export default function EditorPage(props) {
     </button>
   );
 
+  const saveLocallyButton = (
+    <button
+      className="btn btn-primary"
+      // disabled={!widgetName}
+      // onClick={(e) => {
+      // }}
+    >
+      Save in Local Storage
+    </button>
+  );
   const publishButton = (
     <CommitButton
       className={`btn btn-primary`}

--- a/src/pages/EditorPage.js
+++ b/src/pages/EditorPage.js
@@ -674,6 +674,12 @@ export default function EditorPage(props) {
     </button>
   );
 
+  const openCreateButton = (
+    <button className="btn btn-primary" onClick={() => setShowOpenModal(true)}>
+      Open / Create
+    </button>
+  );
+
   const renameButton = (
     <button
       className="btn btn-outline-success ms-2"

--- a/src/pages/EditorPage.js
+++ b/src/pages/EditorPage.js
@@ -318,7 +318,7 @@ export default function EditorPage(props) {
 
   useEffect(() => {
     if (files) {
-      files.forEach(f => {
+      files.forEach((f) => {
         const widgetSrc = `${accountId}/widget/${f.name}/**`;
         const fetchCodeAndDraftOnChain = () => {
           const widgetCode = cache.socialGet(
@@ -332,27 +332,32 @@ export default function EditorPage(props) {
 
           const mainCode = widgetCode?.[""];
           const draft = widgetCode?.branch?.draft?.[""];
-          const isDraft = (!draft && !mainCode) || draft;  
+          const isDraft = (!draft && !mainCode) || draft;
           const path = f;
 
           cache
-          .asyncLocalStorageGet(StorageDomain, {
-            path,
-            type: StorageType.Code,
-          })
-          .then(({ code }) => {
-            let hasCodeChanged;
-            if (draft) {
-              hasCodeChanged = draft != code;
-            } else if (mainCode) {
-              hasCodeChanged = mainCode != code;
-            } else {
-              // no code on chain
-              hasCodeChanged = true;
-            }
-            setFilesDetails(filesDetails.set(f.name, {codeChangesPresent: hasCodeChanged, isDraft}));
-          })
-        }
+            .asyncLocalStorageGet(StorageDomain, {
+              path,
+              type: StorageType.Code,
+            })
+            .then(({ code }) => {
+              let hasCodeChanged;
+              if (draft) {
+                hasCodeChanged = draft != code;
+              } else if (mainCode) {
+                hasCodeChanged = mainCode != code;
+              } else {
+                // no code on chain
+                hasCodeChanged = true;
+              }
+              setFilesDetails(
+                filesDetails.set(f.name, {
+                  codeChangesPresent: hasCodeChanged,
+                  isDraft,
+                })
+              );
+            });
+        };
         fetchCodeAndDraftOnChain();
       });
     }

--- a/src/pages/EditorPage.js
+++ b/src/pages/EditorPage.js
@@ -626,30 +626,6 @@ export default function EditorPage(props) {
     </button>
   );
 
-  const saveLocallyButton = (
-    <button
-      className="btn btn-primary"
-      // disabled={!widgetName}
-      // onClick={(e) => {
-      // }}
-    >
-      Save in Local Storage
-    </button>
-  );
-
-  const saveDraftButton = (
-    <button
-      className="btn btn-danger"
-      disabled={!widgetName}
-      onClick={(e) => {
-        e.preventDefault();
-        setShowSaveDraftModal(true);
-      }}
-    >
-      Save Draft on chain
-    </button>
-  );
-
   const publishButton = (
     <CommitButton
       className={`btn btn-primary`}

--- a/src/pages/EditorPage.js
+++ b/src/pages/EditorPage.js
@@ -636,6 +636,20 @@ export default function EditorPage(props) {
       Save in Local Storage
     </button>
   );
+
+  const saveDraftButton = (
+    <button
+      className="btn btn-danger"
+      disabled={!widgetName}
+      onClick={(e) => {
+        e.preventDefault();
+        setShowSaveDraftModal(true);
+      }}
+    >
+      Save Draft on chain
+    </button>
+  );
+
   const publishButton = (
     <CommitButton
       className={`btn btn-primary`}


### PR DESCRIPTION
This PR introduces a new editor UI and includes publishing a draft mechanism. The following sources were used as a point of reference:

- Loom Video: [loom](https://www.loom.com/share/25387f1382824e3c83b4887880de4b55)
- Prototype Link: [figma](https://www.figma.com/proto/GS9OJozTJ1PZBkTfJ3V8g5/Near-Social-v2?page-id=989%3A7965&node-id=1008%3A7686&viewport=694%2C-738%2C0.65&scaling=min-zoom&starting-point-node-id=1008%3A7686)

Due to the last minute effort the code is not refactored and the following changes are NOT present in this PR:
- the Saving Data modal has not been modified, as it’s imported from the VM
- due to the above point, the order of buttons in other models hasn't been changed at all (for the sake of consistency)
- Search in Add Component modal is not doable right now - it requires significant amount of effort. Due to that there is an Open Component button in this modal

This PR closes two issues from the nearsocial/viewer repo:
https://github.com/NearSocial/viewer/issues/137
https://github.com/NearSocial/viewer/issues/147