### PR TITLE
fix: Reference components by environment

### DIFF
--- a/src/components/navigation/alpha/NavigationButton.js
+++ b/src/components/navigation/alpha/NavigationButton.js
@@ -51,9 +51,7 @@ export function NavigationButton(props) {
               if (location.pathname === "/") {
                 return true;
               }
-              return (
-                location.pathname === "/calebjacob.near/widget/ActivityPage"
-              );
+              return location.pathname === `/${props.widgets?.default}`;
             }
           }}
         >

--- a/src/components/navigation/alpha/desktop/DesktopNavigation.js
+++ b/src/components/navigation/alpha/desktop/DesktopNavigation.js
@@ -119,7 +119,7 @@ export function DesktopNavigation(props) {
             onSubmit={(e) => {
               e.preventDefault();
               history.push(
-                `/calebjacob.near/widget/GlobalSearchPage?term=${e.target[0].value}`
+                `/${props.widgets?.globalSearchPage}?term=${e.target[0].value}`
               );
             }}
           >
@@ -153,7 +153,7 @@ export function DesktopNavigation(props) {
           {props.signedIn && (
             <>
               <NotificationWidget
-                notificationButtonSrc="calebjacob.near/widget/NotificationButton"
+                notificationButtonSrc={props.widgets.notificationButton}
                 onMouseEnter={() => setMenuDropdown(false)}
               />
               <UserDropdown

--- a/src/components/navigation/alpha/desktop/UserDropdown.js
+++ b/src/components/navigation/alpha/desktop/UserDropdown.js
@@ -152,7 +152,7 @@ export function UserDropdown(props) {
             <NavLink
               className="dropdown-item"
               type="button"
-              to={`/calebjacob.near/widget/ProfilePage?accountId=${account.accountId}`}
+              to={`/${props.widgets?.profilePage}?accountId=${account.accountId}`}
             >
               <User />
               My Profile

--- a/src/components/navigation/alpha/desktop/nav_dropdown/NavDropdownMenu.js
+++ b/src/components/navigation/alpha/desktop/nav_dropdown/NavDropdownMenu.js
@@ -74,7 +74,7 @@ export function NavDropdownMenu(props) {
           <div className="section-title">Current component</div>
           <div className="current-app-wrapper">
             <Widget
-              src="calebjacob.near/widget/ComponentSummary"
+              src={props.widgets.componentSummary}
               props={{
                 src: props.widgetSrc?.view,
                 size: "medium",
@@ -89,6 +89,7 @@ export function NavDropdownMenu(props) {
             <NavDropdownMenuLinkList
               category="discover"
               onClick={props.onClickLink}
+              {...props}
             />
           </div>
         ) : (

--- a/src/components/navigation/alpha/desktop/nav_dropdown/NavDropdownMenuLinkList.js
+++ b/src/components/navigation/alpha/desktop/nav_dropdown/NavDropdownMenuLinkList.js
@@ -55,14 +55,14 @@ export function NavDropdownMenuLinkList(props) {
     {
       title: "Components",
       description: "Discover and use new components on NEAR.",
-      link: "/calebjacob.near/widget/ComponentsPage",
+      link: `/${props.widgets?.componentsPage}`,
       icon: Apps,
       category: "discover",
     },
     {
       title: "Community",
       description: "Connect with friends and follow inspiring creators.",
-      link: "/calebjacob.near/widget/PeoplePage",
+      link: `/${props.widgets?.peoplePage}`,
       icon: UserCircle,
       category: "discover",
     },

--- a/src/components/navigation/alpha/mobile/BottomNavigation.js
+++ b/src/components/navigation/alpha/mobile/BottomNavigation.js
@@ -70,21 +70,21 @@ export function BottomNavigation(props) {
   const location = useLocation();
   return (
     <StyledNavigation>
-      <NavigationButton route="/" homeRoute>
+      <NavigationButton route="/" homeRoute {...props}>
         <HouseLine />
       </NavigationButton>
-      <NavigationButton route="/calebjacob.near/widget/GlobalSearchPage">
+      <NavigationButton route={`/${props.widgets.globalSearchPage}`}>
         <MagnifyingGlass />
       </NavigationButton>
       {props.signedIn ? (
         <div
           className={
-            location.pathname === "/calebjacob.near/widget/NotificationsPage"
+            location.pathname === `/${props.widgets.notificationsPage}`
               ? "active-link"
               : ""
           }
         >
-          <Widget src="calebjacob.near/widget/NotificationButton" />
+          <Widget src={props.widgets.notificationButton} />
         </div>
       ) : (
         <div className="bell-wrapper">
@@ -93,7 +93,7 @@ export function BottomNavigation(props) {
       )}
       {props.signedIn ? (
         <NavigationButton
-          route={`/calebjacob.near/widget/ProfilePage?accountId=${props.signedAccountId}`}
+          route={`/${props.widgets.profilePage}?accountId=${props.signedAccountId}`}
         >
           <UserLarge />
         </NavigationButton>

--- a/src/components/navigation/alpha/mobile/MenuLeft.js
+++ b/src/components/navigation/alpha/mobile/MenuLeft.js
@@ -213,13 +213,13 @@ export function MenuLeft(props) {
         <div className="links-title">Discover</div>
         <ul className="top-links">
           <li>
-            <NavigationButton route="/calebjacob.near/widget/ComponentsPage">
+            <NavigationButton route={`/${props.widgets?.componentsPage}`}>
               <Components />
               Components
             </NavigationButton>
           </li>
           <li>
-            <NavigationButton route="/calebjacob.near/widget/PeoplePage">
+            <NavigationButton route={`/${props.widgets?.peoplePage}`}>
               <Community />
               Community
             </NavigationButton>

--- a/src/components/navigation/alpha/mobile/MenuRight.js
+++ b/src/components/navigation/alpha/mobile/MenuRight.js
@@ -127,7 +127,7 @@ export function MenuRight(props) {
         </button>
         <div className="current-app-wrapper">
           <Widget
-            src="calebjacob.near/widget/ComponentSummary"
+            src={props.widgets.componentSummary}
             props={{
               src: props.widgetSrc?.view,
               size: "medium",

--- a/src/data/widgets.js
+++ b/src/data/widgets.js
@@ -7,14 +7,20 @@ export const NetworkId =
   window.location.hostname in TestnetDomains ? "testnet" : "mainnet";
 const TestnetWidgets = {
   image: "eugenethedream/widget/Image",
-  default: "eugenethedream/widget/Welcome",
+  default: "one.testnet/widget/ActivityPage",
   viewSource: "eugenethedream/widget/WidgetSource",
   widgetMetadataEditor: "eugenethedream/widget/WidgetMetadataEditor",
   widgetMetadata: "eugenethedream/widget/WidgetMetadata",
   profileImage: "eugenethedream/widget/ProfileImage",
   profilePage: "eugenethedream/widget/Profile",
   profileName: "eugenethedream/widget/ProfileName",
-  notificationButton: "eugenethedream/widget/NotificationButton",
+  componentsPage: "one.testnet/widget/ComponentsPage",
+  peoplePage: "one.testnet/widget/PeoplePage",
+  globalSearchPage: "one.testnet/widget/GlobalSearchPage",
+  notificationButton: "one.testnet/widget/NotificationButton",
+  profilePage: "one.testnet/widget/ProfilePage",
+  componentSummary: "one.testnet/widget/ComponentSummary",
+  notificationsPage: "one.testnet/widget/NotificationsPage",
 };
 
 const MainnetWidgets = {
@@ -24,11 +30,16 @@ const MainnetWidgets = {
   widgetMetadataEditor: "mob.near/widget/WidgetMetadataEditor",
   widgetMetadata: "mob.near/widget/WidgetMetadata",
   profileImage: "mob.near/widget/ProfileImage",
-  notificationButton: "mob.near/widget/NotificationButton",
-  profilePage: "mob.near/widget/ProfilePage",
   profileName: "patrick.near/widget/ProfileName",
   editorComponentSearch: "mob.near/widget/Editor.ComponentSearch",
   profileInlineBlock: "mob.near/widget/Profile.InlineBlock",
+  componentsPage: "calebjacob.near/widget/ComponentsPage",
+  peoplePage: "calebjacob.near/widget/PeoplePage",
+  globalSearchPage: "calebjacob.near/widget/GlobalSearchPage",
+  notificationButton: "calebjacob.near/widget/NotificationButton",
+  profilePage: "calebjacob.near/widget/ProfilePage",
+  componentSummary: "calebjacob.near/widget/ComponentSummary",
+  notificationsPage: "calebjacob.near/widget/NotificationsPage",
 };
 
 export const Widgets =


### PR DESCRIPTION
Ported over `mainnet` components from `calebjacob.near` to [`one.testnet`](https://explorer.testnet.near.org/accounts/one.testnet) on `testnet` so that we can reference correct components depending on environment inside `widgets.js`