### PR TITLE
Add Zendesk support widget snippet

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -29,5 +29,7 @@
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
+    <!-- NEAR Discovery Zendesk Support Widget -->
+    <script id="ze-snippet" src="https://static.zdassets.com/ekr/snippet.js?key=1736c8d0-1d86-4080-b622-12accfdb74ca"> </script>
   </body>
 </html>


### PR DESCRIPTION
Add JS code directly to index.html to provide a support widget for alpha.near.org. The widget feeds into our support Zendesk instance; we will provide support and answers via Zendesk.

Appearance: Closed
<img width="1451" alt="Screenshot 2023-03-17 at 1 56 21 PM" src="https://user-images.githubusercontent.com/1775283/225994044-8a177fdb-0860-4799-b10a-0173ca143b18.png">

Appearance: Open
<img width="1451" alt="Screenshot 2023-03-17 at 1 56 17 PM" src="https://user-images.githubusercontent.com/1775283/225994067-69df537c-5b89-4e35-ae2b-403fcf59385a.png">
