### PR TITLE
Adding DS.Theme wrapper to provide global design system variables

### DIFF
--- a/src/data/widgets.js
+++ b/src/data/widgets.js
@@ -23,6 +23,7 @@ const TestnetWidgets = {
   notificationsPage: "one.testnet/widget/NotificationsPage",
   tosCheck: "one.testnet/widget/TosCheck",
   tosContent: "one.testnet/widget/TosContent",
+  wrapper: "one.testnet/widget/DS.Theme",
 };
 
 const MainnetWidgets = {
@@ -44,6 +45,7 @@ const MainnetWidgets = {
   notificationsPage: "adminalpha.near/widget/NotificationsPage",
   tosCheck: "adminalpha.near/widget/TosCheck",
   tosContent: "adminalpha.near/widget/TosContent",
+  wrapper: "adminalpha.near/widget/DS.Theme",
 };
 
 export const Widgets =

--- a/src/pages/EditorPage.js
+++ b/src/pages/EditorPage.js
@@ -643,7 +643,7 @@ export default function EditorPage(props) {
               draft: {
                 "": null,
                 metadata: null,
-              }
+              },
             },
           },
         },
@@ -730,7 +730,9 @@ export default function EditorPage(props) {
     <a
       className="btn me-2 btn-outline-secondary"
       style={{ height: "38px" }}
-      href={`#/${widgetPath}${filesDetails.get(widgetName)?.isDraft ? "/branch/draft" : ""}`}
+      href={`#/${widgetPath}${
+        filesDetails.get(widgetName)?.isDraft ? "/branch/draft" : ""
+      }`}
       target="_blank"
       rel="noopener noreferrer"
     >
@@ -753,562 +755,608 @@ export default function EditorPage(props) {
   const showEditor = !(files?.length === 1 && files[0]?.unnamed === true);
 
   return (
-    <>
-      <div
-        className={`text-center d-flex justify-content-center min-vh-100 ${
-          showEditor ? `visually-hidden` : ``
-        }`}
-      >
-        <div
-          className="container-fluid mt-5"
-          style={{
-            width: "460px",
-          }}
-        >
-          <h4 style={{ lineHeight: "50px" }}>
-            Welcome to the Component Sandbox!
-          </h4>
-          <p className="text-secondary">
-            Use this sandbox to create, inspect, modify, and compose components
-            to create new experiences on NEAR.
-          </p>
-          <div className="d-flex justify-content-center mt-5">
-            <button
-              className="btn btn-outline-success mb-3"
-              style={{ width: "250px" }}
-              onClick={() => (setShowAddModal(false), setShowOpenModal(true))}
+    <Widget
+      key={props.widgets.wrapper}
+      src={props.widgets.wrapper}
+      props={{
+        children: (
+          <>
+            <div
+              className={`text-center d-flex justify-content-center min-vh-100 ${
+                showEditor ? `visually-hidden` : ``
+              }`}
             >
-              Open Component
-            </button>
-          </div>
-          <div className="w-100 text-center text-secondary mb-3">or</div>
-          <div className="d-flex justify-content-center">
-            <button
-              className="btn btn-success mb-4"
-              style={{ width: "250px" }}
-              onClick={() => (
-                setShowAddModal(false), createNewFile(Filetype.Widget)
-              )}
-            >
-              Create New Component
-            </button>
-          </div>
-        </div>
-      </div>
-      <div className={showEditor ? `` : `visually-hidden`}>
-        <VsCodeBanner />
-
-        <div className="container-fluid mt-1">
-          <RenameModal
-            key={`rename-modal-${jpath}`}
-            show={showRenameModal}
-            name={path?.name}
-            onRename={(newName) => renameFile(newName, code)}
-            onHide={() => setShowRenameModal(false)}
-          />
-          <OpenModal
-            show={showOpenModal}
-            onOpen={(newName) => loadFile(newName)}
-            onHide={() => setShowOpenModal(false)}
-          />
-          <AddModal
-            show={showAddModal}
-            onOpen={() => (setShowAddModal(false), setShowOpenModal(true))}
-            onNew={() => (
-              setShowAddModal(false),
-              setShowRenameModal(true),
-              createNewFile(Filetype.Widget)
-            )}
-            onHide={() => setShowAddModal(false)}
-          />
-          <CreateModal
-            show={showCreateModal}
-            onOpen={(newName) => loadFile(newName)}
-            onNew={() => {
-              createNewFile(Filetype.Widget);
-            }}
-            onHide={() => setShowCreateModal(false)}
-          />
-          <SaveDraftModal
-            show={showSaveDraftModal}
-            onHide={() => setShowSaveDraftModal(false)}
-            near={near}
-            widgetPath={widgetPath}
-            widgetName={widgetName}
-            code={code}
-            metadata={metadata}
-          />
-          <div className="">
-            <div className="w-100 d-flex " style={{ flexWrap: "nowrap" }}>
-              <div className="d-flex" style={{ flexWrap: "wrap" }}>
-                <Nav
-                  variant="pills mb-2 mt-2"
-                  activeKey={jpath}
-                  onSelect={(key) => openFile(JSON.parse(key))}
-                >
-                  {files?.map((p, idx) => {
-                    if (p.unnamed) {
-                      return;
-                    }
-
-                    const jp = JSON.stringify(p);
-                    const widgetName = p?.name?.split("/")[0];
-                    const { codeChangesPresent, isDraft } =
-                      filesDetails.get(widgetName) || {};
-
-                    return (
-                      <Nav.Item key={jp}>
-                        <TopMenu>
-                          <Nav.Link
-                            className="text-decoration-none d-flex "
-                            eventKey={jp}
-                          >
-                            <div className="d-flex">
-                              {/* X1 */}
-                              {isDraft && <div className="draft">Draft</div>}
-                              <div>{widgetName}</div>
-                              {codeChangesPresent && (
-                                <div className="dot"></div>
-                              )}
-                            </div>
-                            <button
-                              className={`close btn btn-lg border-0 py-0 px-1 ms-1 rounded-circle btn-outline-secondary`}
-                              style={{
-                                marginTop: "-3px",
-                                marginBottom: "0px",
-                              }}
-                              onClick={(e) => {
-                                e.preventDefault();
-                                e.stopPropagation();
-                                removeFromFiles(p);
-                                if (jp === jpath) {
-                                  if (files.length > 1) {
-                                    openFile(files[idx - 1] || files[idx + 1]);
-                                  } else {
-                                    createFile(Filetype.Widget);
-                                  }
-                                }
-                              }}
-                            >
-                              <i className="bi bi-x"></i>
-                            </button>
-                          </Nav.Link>
-                        </TopMenu>
-                      </Nav.Item>
-                    );
-                  })}
-                  <Nav.Item className="me-1">
-                    {openCreateButton}
-                    {renameButton}
-                  </Nav.Item>
-                </Nav>
-              </div>
               <div
-                className="d-flex ms-auto"
-                style={{ minWidth: "280px", flexWrap: "wrap" }}
+                className="container-fluid mt-5"
+                style={{
+                  width: "460px",
+                }}
               >
-                <Nav
-                  variant="pills mb-2 mt-2 ms-auto"
-                  activeKey={jpath}
-                  onSelect={(key) => openFile(JSON.parse(key))}
-                >
-                  <Nav.Item className="">
-                    {saveDraftButton}
-                    {forkButton}
-
-                    {filesDetails.get(widgetName)?.isDraft
-                      ? publishDraftAsMainButton
-                      : publishButton}
-                  </Nav.Item>
-                </Nav>
+                <h4 style={{ lineHeight: "50px" }}>
+                  Welcome to the Component Sandbox!
+                </h4>
+                <p className="text-secondary">
+                  Use this sandbox to create, inspect, modify, and compose
+                  components to create new experiences on NEAR.
+                </p>
+                <div className="d-flex justify-content-center mt-5">
+                  <button
+                    className="btn btn-outline-success mb-3"
+                    style={{ width: "250px" }}
+                    onClick={() => (
+                      setShowAddModal(false), setShowOpenModal(true)
+                    )}
+                  >
+                    Open Component
+                  </button>
+                </div>
+                <div className="w-100 text-center text-secondary mb-3">or</div>
+                <div className="d-flex justify-content-center">
+                  <button
+                    className="btn btn-success mb-4"
+                    style={{ width: "250px" }}
+                    onClick={() => (
+                      setShowAddModal(false), createNewFile(Filetype.Widget)
+                    )}
+                  >
+                    Create New Component
+                  </button>
+                </div>
               </div>
             </div>
+            <div className={showEditor ? `` : `visually-hidden`}>
+              <VsCodeBanner />
 
-            {props.widgets.editorComponentSearch && (
-              <div>
-                {/* We use the component search widget as a VM entry point to add a TOS check wrapper.
-                It does not need to be this component, just some <Widget /> on the page */}
-                <Widget
-                  src={props.tos.checkComponentPath}
-                  props={{
-                    logOut: props.logOut,
-                    tosName: props.tos.contentComponentPath,
-                    targetComponent: props.widgets.editorComponentSearch,
-                    targetProps: useMemo(
-                      () => ({
-                        extraButtons: ({ widgetName, widgetPath, onHide }) => (
-                          <OverlayTrigger
-                            placement="auto"
-                            overlay={
-                              <Tooltip>
-                                Open "{widgetName}" component in the editor
-                              </Tooltip>
-                            }
-                          >
-                            <button
-                              className="btn btn-outline-primary"
-                              onClick={(e) => {
-                                e.preventDefault();
-                                loadFile(widgetPath);
-                                onHide && onHide();
-                              }}
-                            >
-                              Open
-                            </button>
-                          </OverlayTrigger>
-                        ),
-                      }),
-                      [loadFile]
-                    ),
-                  }}
+              <div className="container-fluid mt-1">
+                <RenameModal
+                  key={`rename-modal-${jpath}`}
+                  show={showRenameModal}
+                  name={path?.name}
+                  onRename={(newName) => renameFile(newName, code)}
+                  onHide={() => setShowRenameModal(false)}
                 />
-              </div>
-            )}
-          </div>
-          <div className="d-flex align-content-start">
-            <div className="flex-grow-1">
-              <div className="row">
-                <div className={layoutClass}>
-                  <div
-                    style={{
-                      display: "flex",
-                    }}
-                  >
-                    <div>
-                      <ul
-                        className={`nav nav-tabs`}
-                        style={{
-                          borderBottom: "0px",
-                          marginTop: "9px",
-                        }}
+                <OpenModal
+                  show={showOpenModal}
+                  onOpen={(newName) => loadFile(newName)}
+                  onHide={() => setShowOpenModal(false)}
+                />
+                <AddModal
+                  show={showAddModal}
+                  onOpen={() => (
+                    setShowAddModal(false), setShowOpenModal(true)
+                  )}
+                  onNew={() => (
+                    setShowAddModal(false),
+                    setShowRenameModal(true),
+                    createNewFile(Filetype.Widget)
+                  )}
+                  onHide={() => setShowAddModal(false)}
+                />
+                <CreateModal
+                  show={showCreateModal}
+                  onOpen={(newName) => loadFile(newName)}
+                  onNew={() => {
+                    createNewFile(Filetype.Widget);
+                  }}
+                  onHide={() => setShowCreateModal(false)}
+                />
+                <SaveDraftModal
+                  show={showSaveDraftModal}
+                  onHide={() => setShowSaveDraftModal(false)}
+                  near={near}
+                  widgetPath={widgetPath}
+                  widgetName={widgetName}
+                  code={code}
+                  metadata={metadata}
+                />
+                <div className="">
+                  <div className="w-100 d-flex " style={{ flexWrap: "nowrap" }}>
+                    <div className="d-flex" style={{ flexWrap: "wrap" }}>
+                      <Nav
+                        variant="pills mb-2 mt-2"
+                        activeKey={jpath}
+                        onSelect={(key) => openFile(JSON.parse(key))}
                       >
-                        <li className="nav-item">
-                          <button
-                            className={`nav-link ${
-                              tab === Tab.Editor ? "active" : "text-secondary"
-                            }`}
-                            aria-current="page"
-                            onClick={() => setTab(Tab.Editor)}
-                          >
-                            Component
-                          </button>
-                        </li>
-                        <li className="nav-item">
-                          <button
-                            className={`nav-link ${
-                              tab === Tab.Props ? "active" : "text-secondary"
-                            }`}
-                            aria-current="page"
-                            onClick={() => setTab(Tab.Props)}
-                          >
-                            Props
-                          </button>
-                        </li>
-                        {props.widgets.widgetMetadataEditor && (
-                          <li className="nav-item">
-                            <button
-                              className={`nav-link ${
-                                tab === Tab.Metadata
-                                  ? "active"
-                                  : "text-secondary"
-                              }`}
-                              aria-current="page"
-                              onClick={() => setTab(Tab.Metadata)}
-                            >
-                              Metadata
-                            </button>
-                          </li>
-                        )}
-                        {layout === Layout.Tabs && (
-                          <li className="nav-item">
-                            <button
-                              className={`nav-link ${
-                                tab === Tab.Widget ? "active" : "text-secondary"
-                              }`}
-                              aria-current="page"
-                              onClick={() => {
-                                setRenderCode(code);
-                                setTab(Tab.Widget);
-                              }}
-                            >
-                              Component Preview
-                            </button>
-                          </li>
-                        )}
-                      </ul>
+                        {files?.map((p, idx) => {
+                          if (p.unnamed) {
+                            return;
+                          }
+
+                          const jp = JSON.stringify(p);
+                          const widgetName = p?.name?.split("/")[0];
+                          const { codeChangesPresent, isDraft } =
+                            filesDetails.get(widgetName) || {};
+
+                          return (
+                            <Nav.Item key={jp}>
+                              <TopMenu>
+                                <Nav.Link
+                                  className="text-decoration-none d-flex "
+                                  eventKey={jp}
+                                >
+                                  <div className="d-flex">
+                                    {/* X1 */}
+                                    {isDraft && (
+                                      <div className="draft">Draft</div>
+                                    )}
+                                    <div>{widgetName}</div>
+                                    {codeChangesPresent && (
+                                      <div className="dot"></div>
+                                    )}
+                                  </div>
+                                  <button
+                                    className={`close btn btn-lg border-0 py-0 px-1 ms-1 rounded-circle btn-outline-secondary`}
+                                    style={{
+                                      marginTop: "-3px",
+                                      marginBottom: "0px",
+                                    }}
+                                    onClick={(e) => {
+                                      e.preventDefault();
+                                      e.stopPropagation();
+                                      removeFromFiles(p);
+                                      if (jp === jpath) {
+                                        if (files.length > 1) {
+                                          openFile(
+                                            files[idx - 1] || files[idx + 1]
+                                          );
+                                        } else {
+                                          createFile(Filetype.Widget);
+                                        }
+                                      }
+                                    }}
+                                  >
+                                    <i className="bi bi-x"></i>
+                                  </button>
+                                </Nav.Link>
+                              </TopMenu>
+                            </Nav.Item>
+                          );
+                        })}
+                        <Nav.Item className="me-1">
+                          {openCreateButton}
+                          {renameButton}
+                        </Nav.Item>
+                      </Nav>
                     </div>
-                    {layout === Layout.Tabs && (
-                      <div className="ms-auto d-flex">
-                        {path && accountId && openInNewTabButton}
+                    <div
+                      className="d-flex ms-auto"
+                      style={{ minWidth: "280px", flexWrap: "wrap" }}
+                    >
+                      <Nav
+                        variant="pills mb-2 mt-2 ms-auto"
+                        activeKey={jpath}
+                        onSelect={(key) => openFile(JSON.parse(key))}
+                      >
+                        <Nav.Item className="">
+                          {saveDraftButton}
+                          {forkButton}
+
+                          {filesDetails.get(widgetName)?.isDraft
+                            ? publishDraftAsMainButton
+                            : publishButton}
+                        </Nav.Item>
+                      </Nav>
+                    </div>
+                  </div>
+
+                  {props.widgets.editorComponentSearch && (
+                    <div>
+                      {/* We use the component search widget as a VM entry point to add a TOS check wrapper.
+                                It does not need to be this component, just some <Widget /> on the page */}
+                      <Widget
+                        src={props.tos.checkComponentPath}
+                        props={{
+                          logOut: props.logOut,
+                          tosName: props.tos.contentComponentPath,
+                          targetComponent: props.widgets.editorComponentSearch,
+                          targetProps: useMemo(
+                            () => ({
+                              extraButtons: ({
+                                widgetName,
+                                widgetPath,
+                                onHide,
+                              }) => (
+                                <OverlayTrigger
+                                  placement="auto"
+                                  overlay={
+                                    <Tooltip>
+                                      Open "{widgetName}" component in the
+                                      editor
+                                    </Tooltip>
+                                  }
+                                >
+                                  <button
+                                    className="btn btn-outline-primary"
+                                    onClick={(e) => {
+                                      e.preventDefault();
+                                      loadFile(widgetPath);
+                                      onHide && onHide();
+                                    }}
+                                  >
+                                    Open
+                                  </button>
+                                </OverlayTrigger>
+                              ),
+                            }),
+                            [loadFile]
+                          ),
+                        }}
+                      />
+                    </div>
+                  )}
+                </div>
+                <div className="d-flex align-content-start">
+                  <div className="flex-grow-1">
+                    <div className="row">
+                      <div className={layoutClass}>
                         <div
-                          className="btn-group"
-                          role="group"
-                          aria-label="Layout selection"
                           style={{
-                            height: "38px",
+                            display: "flex",
                           }}
                         >
-                          <input
-                            type="radio"
-                            className="btn-check"
-                            name="layout-radio"
-                            id="layout-tabs"
-                            autoComplete="off"
-                            checked={layout === Layout.Tabs}
-                            onChange={onLayoutChange}
-                            value={Layout.Tabs}
-                            title={"Set layout to Tabs mode"}
-                          />
-                          <label
-                            className="btn btn-outline-secondary"
-                            htmlFor="layout-tabs"
-                          >
-                            <i className="bi bi-square" />
-                          </label>
-                          <input
-                            type="radio"
-                            className="btn-check"
-                            name="layout-radio"
-                            id="layout-split"
-                            autoComplete="off"
-                            checked={layout === Layout.Split}
-                            value={Layout.Split}
-                            title={"Set layout to Split mode"}
-                            onChange={onLayoutChange}
-                          />
-                          <label
-                            className="btn btn-outline-secondary"
-                            htmlFor="layout-split"
-                          >
-                            <i className="bi bi-layout-split" />
-                          </label>
-                        </div>
-                      </div>
-                    )}
-                  </div>
-
-                  <div
-                    className={`${tab === Tab.Editor ? "" : "visually-hidden"}`}
-                  >
-                    <div
-                      className="form-control mb-3"
-                      style={{ height: "70vh", borderTopLeftRadius: "0px" }}
-                    >
-                      <Editor
-                        value={code}
-                        path={widgetPath}
-                        defaultLanguage="javascript"
-                        onChange={(code) => updateCode(path, code)}
-                        wrapperProps={{
-                          onBlur: () => reformat(path, code),
-                        }}
-                      />
-                    </div>
-                    <div className="mb-3 d-flex gap-2 flex-wrap"></div>
-                  </div>
-                  <div
-                    className={`${tab === Tab.Props ? "" : "visually-hidden"}`}
-                  >
-                    <div className="form-control" style={{ height: "70vh" }}>
-                      <Editor
-                        value={widgetProps}
-                        defaultLanguage="json"
-                        onChange={(props) => setWidgetProps(props)}
-                        wrapperProps={{
-                          onBlur: () => reformatProps(widgetProps),
-                        }}
-                      />
-                    </div>
-                    <div className=" mb-3">
-                      ^^ Props for debugging (in JSON)
-                    </div>
-                    {propsError && (
-                      <pre className="alert alert-danger">{propsError}</pre>
-                    )}
-                  </div>
-                  <div
-                    className={`${
-                      tab === Tab.Metadata && props.widgets.widgetMetadataEditor
-                        ? ""
-                        : "visually-hidden"
-                    }`}
-                  >
-                    <div
-                      className="mb-3"
-                      style={{
-                        paddingTop: "20px",
-                        padding: "20px",
-                        border: "1px solid rgb(206, 212, 218)",
-                        appearance: "none",
-                        borderRadius: "0.375rem",
-                        height: "70vh",
-                      }}
-                    >
-                      <Widget
-                        src={props.widgets.widgetMetadataEditor}
-                        key={`metadata-editor-${jpath}`}
-                        props={useMemo(
-                          () => ({
-                            widgetPath: widgetPath
-                             + (filesDetails.get(widgetName)?.isDraft ? "/branch/draft" : ""),
-                            onChange: setMetadata,
-                          }),
-                          [widgetPath]
-                        )}
-                      />
-                    </div>
-                  </div>
-                </div>
-                <div
-                  className={`${
-                    tab === Tab.Widget ||
-                    (layout === Layout.Split && tab !== Tab.Metadata)
-                      ? layoutClass
-                      : "visually-hidden"
-                  }`}
-                >
-                  <div style={{}}>
-                    {tab === Tab.Widget || (
-                      <div
-                        style={{
-                          height: "38px",
-                          display: "flex",
-                          marginBottom: "12px",
-                          justifyContent: "end",
-                        }}
-                      >
-                        {tab === Tab.Widget || (
-                          <>
-                            {renderCode && (
-                              <div className="d-flex justify-content-end me-2">
-                                {renderPreviewButton}
+                          <div>
+                            <ul
+                              className={`nav nav-tabs`}
+                              style={{
+                                borderBottom: "0px",
+                                marginTop: "9px",
+                              }}
+                            >
+                              <li className="nav-item">
+                                <button
+                                  className={`nav-link ${
+                                    tab === Tab.Editor
+                                      ? "active"
+                                      : "text-secondary"
+                                  }`}
+                                  aria-current="page"
+                                  onClick={() => setTab(Tab.Editor)}
+                                >
+                                  Component
+                                </button>
+                              </li>
+                              <li className="nav-item">
+                                <button
+                                  className={`nav-link ${
+                                    tab === Tab.Props
+                                      ? "active"
+                                      : "text-secondary"
+                                  }`}
+                                  aria-current="page"
+                                  onClick={() => setTab(Tab.Props)}
+                                >
+                                  Props
+                                </button>
+                              </li>
+                              {props.widgets.widgetMetadataEditor && (
+                                <li className="nav-item">
+                                  <button
+                                    className={`nav-link ${
+                                      tab === Tab.Metadata
+                                        ? "active"
+                                        : "text-secondary"
+                                    }`}
+                                    aria-current="page"
+                                    onClick={() => setTab(Tab.Metadata)}
+                                  >
+                                    Metadata
+                                  </button>
+                                </li>
+                              )}
+                              {layout === Layout.Tabs && (
+                                <li className="nav-item">
+                                  <button
+                                    className={`nav-link ${
+                                      tab === Tab.Widget
+                                        ? "active"
+                                        : "text-secondary"
+                                    }`}
+                                    aria-current="page"
+                                    onClick={() => {
+                                      setRenderCode(code);
+                                      setTab(Tab.Widget);
+                                    }}
+                                  >
+                                    Component Preview
+                                  </button>
+                                </li>
+                              )}
+                            </ul>
+                          </div>
+                          {layout === Layout.Tabs && (
+                            <div className="ms-auto d-flex">
+                              {path && accountId && openInNewTabButton}
+                              <div
+                                className="btn-group"
+                                role="group"
+                                aria-label="Layout selection"
+                                style={{
+                                  height: "38px",
+                                }}
+                              >
+                                <input
+                                  type="radio"
+                                  className="btn-check"
+                                  name="layout-radio"
+                                  id="layout-tabs"
+                                  autoComplete="off"
+                                  checked={layout === Layout.Tabs}
+                                  onChange={onLayoutChange}
+                                  value={Layout.Tabs}
+                                  title={"Set layout to Tabs mode"}
+                                />
+                                <label
+                                  className="btn btn-outline-secondary"
+                                  htmlFor="layout-tabs"
+                                >
+                                  <i className="bi bi-square" />
+                                </label>
+                                <input
+                                  type="radio"
+                                  className="btn-check"
+                                  name="layout-radio"
+                                  id="layout-split"
+                                  autoComplete="off"
+                                  checked={layout === Layout.Split}
+                                  value={Layout.Split}
+                                  title={"Set layout to Split mode"}
+                                  onChange={onLayoutChange}
+                                />
+                                <label
+                                  className="btn btn-outline-secondary"
+                                  htmlFor="layout-split"
+                                >
+                                  <i className="bi bi-layout-split" />
+                                </label>
                               </div>
-                            )}
-                            {path && accountId && openInNewTabButton}
-                            <div
-                              className="btn-group"
-                              role="group"
-                              aria-label="Layout selection"
-                            >
-                              <input
-                                type="radio"
-                                className="btn-check"
-                                name="layout-radio"
-                                id="layout-tabs"
-                                autoComplete="off"
-                                checked={layout === Layout.Tabs}
-                                onChange={onLayoutChange}
-                                value={Layout.Tabs}
-                                title={"Set layout to Tabs mode"}
-                              />
-                              <label
-                                className="btn btn-outline-secondary"
-                                htmlFor="layout-tabs"
-                              >
-                                <i className="bi bi-square" />
-                              </label>
-
-                              <input
-                                type="radio"
-                                className="btn-check"
-                                name="layout-radio"
-                                id="layout-split"
-                                autoComplete="off"
-                                checked={layout === Layout.Split}
-                                value={Layout.Split}
-                                title={"Set layout to Split mode"}
-                                onChange={onLayoutChange}
-                              />
-                              <label
-                                className="btn btn-outline-secondary"
-                                htmlFor="layout-split"
-                              >
-                                <i className="bi bi-layout-split" />
-                              </label>
-                            </div>
-                          </>
-                        )}
-                      </div>
-                    )}
-                    <div
-                      className="container"
-                      style={
-                        tab === Tab.Widget
-                          ? {
-                              border: "1px solid #ced4da",
-                              appearance: "none",
-                              borderRadius: "0.375rem",
-                              height: "70vh",
-                              maxWidth: "100%",
-                              padding: "20px",
-                            }
-                          : {
-                              padding: "20px",
-                              border: "1px solid #ced4da",
-                              appearance: "none",
-                              borderRadius: "0.375rem",
-                              height: "70vh",
-                            }
-                      }
-                    >
-                      <div className="h-100 row">
-                        <div className="d-inline-block position-relative overflow-auto h-100">
-                          {renderCode ? (
-                            <div
-                              style={{
-                                padding: 0,
-                                margin: 0,
-                              }}
-                            >
-                              <Widget
-                                key={`preview-${jpath}`}
-                                code={renderCode}
-                                props={parsedWidgetProps}
-                              />
-                            </div>
-                          ) : (
-                            <div
-                              style={{
-                                padding: 0,
-                                margin: 0,
-                                display: "flex",
-                                alignItems: "center",
-                                justifyContent: "center",
-                              }}
-                            >
-                              {renderPreviewButton}
                             </div>
                           )}
                         </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-                <div
-                  className={`${
-                    tab === Tab.Metadata ? layoutClass : "visually-hidden"
-                  }`}
-                >
-                  <div className="container" style={{ marginTop: "50px" }}>
-                    <div className="row">
-                      <div className="d-inline-block position-relative overflow-hidden">
-                        <Widget
-                          key={`metadata-${jpath}`}
-                          src={props.widgets.widgetMetadata}
-                          props={useMemo(
-                            () => ({ metadata, accountId }),
-                            [metadata, accountId]
+
+                        <div
+                          className={`${
+                            tab === Tab.Editor ? "" : "visually-hidden"
+                          }`}
+                        >
+                          <div
+                            className="form-control mb-3"
+                            style={{
+                              height: "70vh",
+                              borderTopLeftRadius: "0px",
+                            }}
+                          >
+                            <Editor
+                              value={code}
+                              path={widgetPath}
+                              defaultLanguage="javascript"
+                              onChange={(code) => updateCode(path, code)}
+                              wrapperProps={{
+                                onBlur: () => reformat(path, code),
+                              }}
+                            />
+                          </div>
+                          <div className="mb-3 d-flex gap-2 flex-wrap"></div>
+                        </div>
+                        <div
+                          className={`${
+                            tab === Tab.Props ? "" : "visually-hidden"
+                          }`}
+                        >
+                          <div
+                            className="form-control"
+                            style={{ height: "70vh" }}
+                          >
+                            <Editor
+                              value={widgetProps}
+                              defaultLanguage="json"
+                              onChange={(props) => setWidgetProps(props)}
+                              wrapperProps={{
+                                onBlur: () => reformatProps(widgetProps),
+                              }}
+                            />
+                          </div>
+                          <div className=" mb-3">
+                            ^^ Props for debugging (in JSON)
+                          </div>
+                          {propsError && (
+                            <pre className="alert alert-danger">
+                              {propsError}
+                            </pre>
                           )}
-                        />
+                        </div>
+                        <div
+                          className={`${
+                            tab === Tab.Metadata &&
+                            props.widgets.widgetMetadataEditor
+                              ? ""
+                              : "visually-hidden"
+                          }`}
+                        >
+                          <div
+                            className="mb-3"
+                            style={{
+                              paddingTop: "20px",
+                              padding: "20px",
+                              border: "1px solid rgb(206, 212, 218)",
+                              appearance: "none",
+                              borderRadius: "0.375rem",
+                              height: "70vh",
+                            }}
+                          >
+                            <Widget
+                              src={props.widgets.widgetMetadataEditor}
+                              key={`metadata-editor-${jpath}`}
+                              props={useMemo(
+                                () => ({
+                                  widgetPath:
+                                    widgetPath +
+                                    (filesDetails.get(widgetName)?.isDraft
+                                      ? "/branch/draft"
+                                      : ""),
+                                  onChange: setMetadata,
+                                }),
+                                [widgetPath]
+                              )}
+                            />
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className={`${
+                          tab === Tab.Widget ||
+                          (layout === Layout.Split && tab !== Tab.Metadata)
+                            ? layoutClass
+                            : "visually-hidden"
+                        }`}
+                      >
+                        <div style={{}}>
+                          {tab === Tab.Widget || (
+                            <div
+                              style={{
+                                height: "38px",
+                                display: "flex",
+                                marginBottom: "12px",
+                                justifyContent: "end",
+                              }}
+                            >
+                              {tab === Tab.Widget || (
+                                <>
+                                  {renderCode && (
+                                    <div className="d-flex justify-content-end me-2">
+                                      {renderPreviewButton}
+                                    </div>
+                                  )}
+                                  {path && accountId && openInNewTabButton}
+                                  <div
+                                    className="btn-group"
+                                    role="group"
+                                    aria-label="Layout selection"
+                                  >
+                                    <input
+                                      type="radio"
+                                      className="btn-check"
+                                      name="layout-radio"
+                                      id="layout-tabs"
+                                      autoComplete="off"
+                                      checked={layout === Layout.Tabs}
+                                      onChange={onLayoutChange}
+                                      value={Layout.Tabs}
+                                      title={"Set layout to Tabs mode"}
+                                    />
+                                    <label
+                                      className="btn btn-outline-secondary"
+                                      htmlFor="layout-tabs"
+                                    >
+                                      <i className="bi bi-square" />
+                                    </label>
+
+                                    <input
+                                      type="radio"
+                                      className="btn-check"
+                                      name="layout-radio"
+                                      id="layout-split"
+                                      autoComplete="off"
+                                      checked={layout === Layout.Split}
+                                      value={Layout.Split}
+                                      title={"Set layout to Split mode"}
+                                      onChange={onLayoutChange}
+                                    />
+                                    <label
+                                      className="btn btn-outline-secondary"
+                                      htmlFor="layout-split"
+                                    >
+                                      <i className="bi bi-layout-split" />
+                                    </label>
+                                  </div>
+                                </>
+                              )}
+                            </div>
+                          )}
+                          <div
+                            className="container"
+                            style={
+                              tab === Tab.Widget
+                                ? {
+                                    border: "1px solid #ced4da",
+                                    appearance: "none",
+                                    borderRadius: "0.375rem",
+                                    height: "70vh",
+                                    maxWidth: "100%",
+                                    padding: "20px",
+                                  }
+                                : {
+                                    padding: "20px",
+                                    border: "1px solid #ced4da",
+                                    appearance: "none",
+                                    borderRadius: "0.375rem",
+                                    height: "70vh",
+                                  }
+                            }
+                          >
+                            <div className="h-100 row">
+                              <div className="d-inline-block position-relative overflow-auto h-100">
+                                {renderCode ? (
+                                  <div
+                                    style={{
+                                      padding: 0,
+                                      margin: 0,
+                                    }}
+                                  >
+                                    <Widget
+                                      key={`preview-${jpath}`}
+                                      code={renderCode}
+                                      props={parsedWidgetProps}
+                                    />
+                                  </div>
+                                ) : (
+                                  <div
+                                    style={{
+                                      padding: 0,
+                                      margin: 0,
+                                      display: "flex",
+                                      alignItems: "center",
+                                      justifyContent: "center",
+                                    }}
+                                  >
+                                    {renderPreviewButton}
+                                  </div>
+                                )}
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <div
+                        className={`${
+                          tab === Tab.Metadata ? layoutClass : "visually-hidden"
+                        }`}
+                      >
+                        <div
+                          className="container"
+                          style={{ marginTop: "50px" }}
+                        >
+                          <div className="row">
+                            <div className="d-inline-block position-relative overflow-hidden">
+                              <Widget
+                                key={`metadata-${jpath}`}
+                                src={props.widgets.widgetMetadata}
+                                props={useMemo(
+                                  () => ({ metadata, accountId }),
+                                  [metadata, accountId]
+                                )}
+                              />
+                            </div>
+                          </div>
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
               </div>
             </div>
-          </div>
-        </div>
-      </div>
-    </>
+          </>
+        ),
+      }}
+    />
   );
 }

--- a/src/pages/EmbedPage.js
+++ b/src/pages/EmbedPage.js
@@ -30,15 +30,23 @@ export default function EmbedPage(props) {
   return (
     <div className="d-inline-block position-relative overflow-hidden">
       <Widget
-        key={props.tos.checkComponentPath}
-        src={props.tos.checkComponentPath}
+        key={props.widgets.wrapper}
+        src={props.widgets.wrapper}
         props={{
-          logOut: props.logOut,
-          tosName: props.tos.contentComponentPath,
-          targetComponent: src,
-          targetProps: widgetProps,
+          children: (
+            <Widget
+              key={props.tos.checkComponentPath}
+              src={props.tos.checkComponentPath}
+              props={{
+                logOut: props.logOut,
+                tosName: props.tos.contentComponentPath,
+                targetComponent: src,
+                targetProps: widgetProps,
+              }}
+            />
+          ),
         }}
-      />{" "}
+      />
     </div>
   );
 }

--- a/src/pages/ViewPage.js
+++ b/src/pages/ViewPage.js
@@ -48,15 +48,23 @@ export default function ViewPage(props) {
           }}
         >
           <Widget
-            key={props.tos.checkComponentPath}
-            src={props.tos.checkComponentPath}
+            key={props.widgets.wrapper}
+            src={props.widgets.wrapper}
             props={{
-              logOut: props.logOut,
-              targetProps: widgetProps,
-              targetComponent: src,
-              tosName: props.tos.contentComponentPath,
+              children: (
+                <Widget
+                  key={props.tos.checkComponentPath}
+                  src={props.tos.checkComponentPath}
+                  props={{
+                    logOut: props.logOut,
+                    targetProps: widgetProps,
+                    targetComponent: src,
+                    tosName: props.tos.contentComponentPath,
+                  }}
+                />
+              ),
             }}
-          />{" "}
+          />
         </div>
       </div>
     </div>


### PR DESCRIPTION
Wraps all viewer pages with our `DS.Theme` component (already published to mainnet and testnet):

https://alpha.near.org/#/adminalpha.near/widget/ComponentDetailsPage?src=adminalpha.near/widget/DS.Theme
https://test.near.social/#/eugenethedream/widget/WidgetSource?src=one.testnet/widget/DS.Theme